### PR TITLE
Release/v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rtlp-lib"
-version = "0.2.2"
-edition = "2021"
+version = "0.3.0"
+edition = "2024"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]
 license = "BSD-3-Clause"
 description = "This create provide structures to parse PCI TLPs"


### PR DESCRIPTION
## Summary

Merges `refactor/improve-error-handling` into `main` and bumps the crate to
`v0.3.0`. This PR addresses critical error-handling bugs, cleans up the public
API, and fixes all clippy warnings.

## Breaking Changes

- `TlpPacket::get_tlp_type()` now returns `Result<TlpType, TlpError>` instead
  of panicking with `.expect()`
- `TlpError` enum simplified — `UnknownEncoding` variant removed; replaced by
  `InvalidFormat`, `InvalidType`, and `UnsupportedCombination`
- `TryFrom` error type changed from `()` to `TlpError` across the board

## Bug Fixes

- **Critical:** `InvalidFormat` errors were silently swallowed by wildcard match
  arms and misreported as `UnsupportedCombination`
- `InvalidType` error variant was defined but never actually returned — now it is
- Error propagation fixed in all `TlpFormatEncodingType` match arms

## Improvements

- `TlpPacketHeader::get_tlp_type()` no longer allocates unnecessarily
- Removed unused `bytes` field from `TlpPacketHeader`
- Removed leftover debug `println!` from Completion parsing
- Fixed all clippy warnings: `redundant_field_names`, `unnecessary_cast`,
  `result_unit_err`
- README examples updated to reflect the new `Result`-based API

## Tests

- 4 new tests covering all error paths (`InvalidFormat`, `InvalidType`,
  `UnsupportedCombination`, `TlpPacket` error propagation)
- All **14 unit tests + 5 doc tests** passing

## Other

- Edition bumped `2021 → 2024`
- Version `0.2.2 → 0.3.0`
