### PR TITLE
chore: fix typo, repository URL and missing metadata in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,15 @@
 name = "rtlp-lib"
 version = "0.3.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]
 license = "BSD-3-Clause"
-description = "This create provide structures to parse PCI TLPs"
-repository = "https://github.com/gotoco/rust_tlplib"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Rust library for parsing PCI Express Transaction Layer Packets (TLPs)"
+repository = "https://github.com/mmpg-x86/rust_tlplib"
+documentation = "https://docs.rs/rtlp-lib"
+readme = "README.md"
+keywords = ["pcie", "tlp", "pci-express", "parser", "hardware"]
+categories = ["hardware-support", "parser-implementations"]
 
 [dependencies]
 bitfield = "0.14.0"


### PR DESCRIPTION
### Changes

- **Fix description typo**: *"This create provide structures..."* → *"Rust library for parsing PCI Express Transaction Layer Packets (TLPs)"*
- **Fix repository URL**: `gotoco/rust_tlplib` → `mmpg-x86/rust_tlplib`
- **Add missing metadata fields**:
  - `documentation` → docs.rs link
  - `readme` → README.md
  - `keywords` → pcie, tlp, pci-express, parser, hardware
  - `categories` → hardware-support, parser-implementations
  - `rust-version` → 1.85 (MSRV for edition 2024)

### No code changes

All 102 tests pass. Clippy clean.