### PR TITLE
fix: return Result from packet constructors to prevent panic on short input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// use rtlp_lib::new_mem_req;
 ///
 /// let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/// let tlp = TlpPacket::new(bytes);
+/// let tlp = TlpPacket::new(bytes).unwrap();
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
 ///     // MemRequest contain only fields specific to PCI Memory Requests
@@ -432,7 +432,7 @@ pub trait ConfigurationRequest {
 /// use rtlp_lib::new_conf_req;
 ///
 /// let bytes = vec![0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/// let tlp = TlpPacket::new(bytes);
+/// let tlp = TlpPacket::new(bytes).unwrap();
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
 ///     let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.get_data(), &tlpfmt);
@@ -681,7 +681,7 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 ///     0x00, 0x00, 0x10, 0x00, // DW2: address32=0x0000_1000
 ///     0x00, 0x00, 0x00, 0x04, // operand: addend=4
 /// ];
-/// let pkt = TlpPacket::new(bytes);
+/// let pkt = TlpPacket::new(bytes).unwrap();
 /// let ar = new_atomic_req(&pkt).unwrap();
 /// assert_eq!(ar.req_id(),   0xABCD);
 /// assert_eq!(ar.operand0(), 4);
@@ -736,11 +736,14 @@ pub struct TlpPacketHeader {
 }
 
 impl TlpPacketHeader {
-    pub fn new(bytes: Vec<u8>) -> TlpPacketHeader {
+    pub fn new(bytes: Vec<u8>) -> Result<TlpPacketHeader, TlpError> {
+        if bytes.len() < 4 {
+            return Err(TlpError::InvalidLength);
+        }
         let mut dw0 = vec![0; 4];
         dw0[..4].clone_from_slice(&bytes[0..4]);
 
-        TlpPacketHeader { header: TlpHeader(dw0) }
+        Ok(TlpPacketHeader { header: TlpHeader(dw0) })
     }
 
     pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
@@ -780,7 +783,7 @@ impl TlpPacketHeader {
 /// // Bytes for full TLP Packet
 /// //               <------- DW1 -------->  <------- DW2 -------->  <------- DW3 -------->  <------- DW4 -------->
 /// let bytes = vec![0x00, 0x00, 0x20, 0x01, 0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
-/// let packet = TlpPacket::new(bytes);
+/// let packet = TlpPacket::new(bytes).unwrap();
 ///
 /// let header = packet.get_header();
 /// // TLP Type tells us what is this packet
@@ -817,15 +820,18 @@ pub struct TlpPacket {
 }
 
 impl TlpPacket {
-    pub fn new(bytes: Vec<u8>) -> TlpPacket {
+    pub fn new(bytes: Vec<u8>) -> Result<TlpPacket, TlpError> {
+        if bytes.len() < 4 {
+            return Err(TlpError::InvalidLength);
+        }
         let mut ownbytes = bytes.to_vec();
         let mut header = vec![0; 4];
         header.clone_from_slice(&ownbytes[0..4]);
         let data = ownbytes.drain(4..).collect();
-        TlpPacket {
-            header: TlpPacketHeader::new(header),
+        Ok(TlpPacket {
+            header: TlpPacketHeader::new(header)?,
             data,
-        }
+        })
     }
 
     pub fn get_header(&self) -> &TlpPacketHeader {
@@ -961,6 +967,29 @@ mod tests {
         let result = invalid_combo.get_tlp_type();
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), TlpError::UnsupportedCombination);
+    }
+
+    // ── short packet rejection ─────────────────────────────────────────────
+
+    #[test]
+    fn packet_new_rejects_empty_input() {
+        assert!(matches!(TlpPacket::new(vec![]), Err(TlpError::InvalidLength)));
+    }
+
+    #[test]
+    fn packet_new_rejects_3_bytes() {
+        assert!(matches!(TlpPacket::new(vec![0x00, 0x00, 0x00]), Err(TlpError::InvalidLength)));
+    }
+
+    #[test]
+    fn packet_new_accepts_4_bytes() {
+        // Exactly 4 bytes = header only, no data — should succeed
+        assert!(TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00]).is_ok());
+    }
+
+    #[test]
+    fn packet_header_new_rejects_short_input() {
+        assert!(matches!(TlpPacketHeader::new(vec![0x00, 0x00]), Err(TlpError::InvalidLength)));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -1150,7 +1179,7 @@ mod tests {
             0xAB, 0xCD, 0x42, 0x0F, // req_id=0xABCD, tag=0x42, BE=0x0F
             0xDE, 0xAD, 0x00, 0x00, // address32=0xDEAD0000
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b11011, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b11011, &payload)).unwrap();
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
@@ -1168,7 +1197,7 @@ mod tests {
             0x11, 0x22, 0x33, 0x44, // address64 hi
             0x55, 0x66, 0x77, 0x88, // address64 lo
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b11011, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b11011, &payload)).unwrap();
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
@@ -1231,7 +1260,7 @@ mod tests {
             0x89, 0xAB, 0xCD, 0xEF, // address32
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload));
+        let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload)).unwrap();
 
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
@@ -1260,7 +1289,7 @@ mod tests {
             0x55, 0x66, 0x77, 0x88, // address64 low DW
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload));
+        let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload)).unwrap();
 
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
@@ -1285,7 +1314,7 @@ mod tests {
             0xC0, 0x01, 0x00, 0x04, // address32
             0x00, 0x00, 0x00, 0x0A, // addend (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &payload)).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::FetchAdd);
@@ -1308,7 +1337,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // address64
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // addend (W64)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01100, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01100, &payload)).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::FetchAdd);
@@ -1331,7 +1360,7 @@ mod tests {
             0xF0, 0x00, 0x00, 0x08, // address32
             0xAB, 0xCD, 0xEF, 0x01, // new_value (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01101, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01101, &payload)).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::Swap);
@@ -1356,7 +1385,7 @@ mod tests {
             0xCA, 0xFE, 0xBA, 0xBE, // compare (W32)
             0xDE, 0xAD, 0xBE, 0xEF, // swap    (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01110, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01110, &payload)).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::CompareSwap);
@@ -1381,7 +1410,7 @@ mod tests {
             0x01, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02, 0x02, // compare (W64)
             0x03, 0x03, 0x03, 0x03, 0x04, 0x04, 0x04, 0x04, // swap    (W64)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &payload));
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &payload)).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::CompareSwap);
@@ -1396,7 +1425,7 @@ mod tests {
     #[test]
     fn atomic_req_rejects_wrong_tlp_type() {
         // MemRead type is not an atomic — should get UnsupportedCombination
-        let pkt = TlpPacket::new(mk_tlp(0b000, 0b00000, &[0u8; 16]));
+        let pkt = TlpPacket::new(mk_tlp(0b000, 0b00000, &[0u8; 16])).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
     }
 
@@ -1404,29 +1433,29 @@ mod tests {
     fn atomic_req_rejects_wrong_format() {
         // FetchAdd type with NoData3DW format is an invalid combo:
         // get_tlp_type() returns UnsupportedCombination, which propagates
-        let pkt = TlpPacket::new(mk_tlp(0b000, 0b01100, &[0u8; 16]));
+        let pkt = TlpPacket::new(mk_tlp(0b000, 0b01100, &[0u8; 16])).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
     }
 
     #[test]
     fn atomic_req_rejects_short_payload() {
         // 3 bytes data — FetchAdd 3DW needs exactly 12 (8 hdr + 4 operand)
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 3]));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 3])).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
 
         // 8 bytes data — header OK but operand missing (needs 12)
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 8]));
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 8])).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
 
         // 20 bytes data — CAS 4DW needs exactly 28 (12 hdr + 8 + 8)
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &[0u8; 20]));
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &[0u8; 20])).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
     fn mk_pkt(fmt: u8, typ: u8, data: &[u8]) -> TlpPacket {
-        TlpPacket::new(mk_tlp(fmt, typ, data))
+        TlpPacket::new(mk_tlp(fmt, typ, data)).unwrap()
     }
 
     // ── atomic tier-B (new API): real binary layout, single-argument call ─────

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -125,13 +125,13 @@ fn tlp_type_implements_debug() {
 #[test]
 fn tlp_packet_new_constructor_exists() {
     let data = vec![0x00; 12];
-    let _packet = TlpPacket::new(data);
+    let _packet = TlpPacket::new(data).unwrap();
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     let result: Result<TlpType, TlpError> = packet.get_tlp_type();
     assert!(result.is_ok());
 }
@@ -139,28 +139,28 @@ fn tlp_packet_get_tlp_type_returns_result() {
 #[test]
 fn tlp_packet_get_tlp_type_valid_mem_read() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_mem_write() {
     let data = vec![0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemWriteReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_config_type0_read() {
     let data = vec![0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_error_invalid_format() {
     let data = vec![0xa0, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidFormat);
@@ -169,7 +169,7 @@ fn tlp_packet_get_tlp_type_error_invalid_format() {
 #[test]
 fn tlp_packet_get_tlp_type_error_invalid_type() {
     let data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
@@ -178,7 +178,7 @@ fn tlp_packet_get_tlp_type_error_invalid_type() {
 #[test]
 fn tlp_packet_get_tlp_format_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     let format: Result<TlpFmt, _> = packet.get_tlp_format();
     assert!(format.is_ok());
 }
@@ -186,7 +186,7 @@ fn tlp_packet_get_tlp_format_exists() {
 #[test]
 fn tlp_packet_get_data_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC, 0xDD];
-    let packet = TlpPacket::new(data.clone());
+    let packet = TlpPacket::new(data.clone()).unwrap();
     let returned_data = packet.get_data();
     assert_eq!(returned_data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
 }
@@ -198,13 +198,13 @@ fn tlp_packet_get_data_exists() {
 #[test]
 fn tlp_packet_header_new_constructor_exists() {
     let data = vec![0x00; 12];
-    let _header = TlpPacketHeader::new(data);
+    let _header = TlpPacketHeader::new(data).unwrap();
 }
 
 #[test]
 fn tlp_packet_header_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let header = TlpPacketHeader::new(data);
+    let header = TlpPacketHeader::new(data).unwrap();
     let result: Result<TlpType, TlpError> = header.get_tlp_type();
     assert!(result.is_ok());
 }
@@ -395,7 +395,7 @@ fn new_atomic_req_factory_exists() {
     // DW0: fmt=0b010 (WithData3DW), type=0b01100 (FetchAdd) → byte0 = 0x4C
     let mut bytes = vec![0x4C, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 12]); // 8-byte hdr + 4-byte operand
-    let pkt = TlpPacket::new(bytes);
+    let pkt = TlpPacket::new(bytes).unwrap();
     let result = new_atomic_req(&pkt);
     assert!(result.is_ok());
     let ar = result.unwrap();
@@ -446,7 +446,7 @@ fn atomic_req_returns_err_for_non_atomic_type() {
     // MemRead 3DW NoData: fmt=0b000, type=0b00000 → byte0 = 0x00
     let mut bytes = vec![0x00, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 16]);
-    let pkt = TlpPacket::new(bytes);
+    let pkt = TlpPacket::new(bytes).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::UnsupportedCombination);
 }
@@ -457,7 +457,7 @@ fn atomic_req_returns_err_for_nodata_format() {
     // get_tlp_type() returns UnsupportedCombination for this combo
     let mut bytes = vec![0x0D, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 16]);
-    let pkt = TlpPacket::new(bytes);
+    let pkt = TlpPacket::new(bytes).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::UnsupportedCombination);
 }
@@ -468,7 +468,7 @@ fn atomic_req_returns_err_for_short_payload() {
     // fmt=0b010, type=0b01100 → byte0 = 0x4C
     let mut bytes = vec![0x4C, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 4]);
-    let pkt = TlpPacket::new(bytes);
+    let pkt = TlpPacket::new(bytes).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::InvalidLength);
 }
@@ -521,14 +521,14 @@ fn api_all_expected_public_types_are_available() {
 fn tlp_packet_handles_minimum_size() {
     // 4-byte header minimum
     let data = vec![0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert!(packet.get_tlp_type().is_ok());
 }
 
 #[test]
 fn tlp_packet_handles_empty_data_section() {
     let data = vec![0x00, 0x00, 0x00, 0x01];
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert_eq!(packet.get_data(), Vec::<u8>::new());
 }
 
@@ -537,6 +537,6 @@ fn tlp_packet_preserves_data_payload() {
     let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
     let mut data = vec![0x00, 0x00, 0x00, 0x01];
     data.extend_from_slice(&payload);
-    let packet = TlpPacket::new(data);
+    let packet = TlpPacket::new(data).unwrap();
     assert_eq!(packet.get_data(), payload);
 }

--- a/tests/tlp_tests.rs
+++ b/tests/tlp_tests.rs
@@ -9,13 +9,13 @@ fn mk_pkt(dw0_fmt: u8, dw0_type: u8, data: &[u8]) -> TlpPacket {
     v.push(0);
     v.push(0);
     v.extend_from_slice(data);
-    TlpPacket::new(v)
+    TlpPacket::new(v).unwrap()
 }
 
 #[test]
 fn test_tlp_packet() {
     let d = vec![0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
-    let tlp = TlpPacket::new(d);
+    let tlp = TlpPacket::new(d).unwrap();
 
     assert_eq!(tlp.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
     assert_eq!(tlp.get_data(), vec![0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
@@ -92,7 +92,7 @@ fn is_memreq_4dw_address_works() {
 fn is_tlppacket_creates() {
     let memrd32_header = [0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
 
-    let mr = TlpPacketHeader::new(memrd32_header.to_vec());
+    let mr = TlpPacketHeader::new(memrd32_header.to_vec()).unwrap();
     assert_eq!(mr.get_tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
@@ -100,7 +100,7 @@ fn is_tlppacket_creates() {
 fn test_tlp_packet_invalid_type() {
     // Test that TlpPacket::get_tlp_type properly returns error
     let invalid_data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(invalid_data);
+    let packet = TlpPacket::new(invalid_data).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
@@ -234,7 +234,7 @@ fn atomic_fetchadd_rejects_invalid_operand_length() {
 fn dmwr32_decode_via_tlppacket() {
     // DMWr32: fmt=010, type=11011 → byte0 = 0x5B
     let data = vec![0x5B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let pkt = TlpPacket::new(data);
+    let pkt = TlpPacket::new(data).unwrap();
     assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
     assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 }
@@ -243,7 +243,7 @@ fn dmwr32_decode_via_tlppacket() {
 fn dmwr64_decode_via_tlppacket() {
     // DMWr64: fmt=011, type=11011 → byte0 = 0x7B
     let data = vec![0x7B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let pkt = TlpPacket::new(data);
+    let pkt = TlpPacket::new(data).unwrap();
     assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
     assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 }
@@ -251,11 +251,11 @@ fn dmwr64_decode_via_tlppacket() {
 #[test]
 fn dmwr_rejects_nodata_formats() {
     // NoData 3DW: fmt=000, type=11011 → byte0 = 0x1B
-    let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]).unwrap();
     assert_eq!(pkt1.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 
     // NoData 4DW: fmt=001, type=11011 → byte0 = 0x3B
-    let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]).unwrap();
     assert_eq!(pkt2.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 }
 


### PR DESCRIPTION
### Bug

`TlpPacket::new()` and `TlpPacketHeader::new()` slice `[0..4]` without checking input length. Inputs shorter than 4 bytes cause a panic instead of returning the crate's `TlpError::InvalidLength`.

### Fix

Both constructors now return `Result<Self, TlpError>`:

```rust
// Before
pub fn new(bytes: Vec<u8>) -> TlpPacket          // panics on < 4 bytes
pub fn new(bytes: Vec<u8>) -> TlpPacketHeader     // panics on < 4 bytes

// After
pub fn new(bytes: Vec<u8>) -> Result<TlpPacket, TlpError>
pub fn new(bytes: Vec<u8>) -> Result<TlpPacketHeader, TlpError>
```

**⚠️ Breaking change:** Callers must now handle the `Result`. All doc examples and existing tests are updated.

### Tests added

- `packet_new_rejects_empty_input`
- `packet_new_rejects_3_bytes`
- `packet_new_accepts_4_bytes` (minimum valid)
- `packet_header_new_rejects_short_input`

All 106 tests pass. Clippy clean.