### PR TITLE
fix: reject TlpPrefix format in new_mem_req

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,15 +385,15 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
 ///     // MemRequest contain only fields specific to PCI Memory Requests
-///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt).unwrap();
+///     if let Ok(mem_req) = new_mem_req(tlp.get_data(), &tlpfmt) {
+///         // Address is 64 bits regardles of TLP format
+///         //println!("Memory Request Address: {:x}", mem_req.address());
 ///
-///     // Address is 64 bits regardles of TLP format
-///     //println!("Memory Request Address: {:x}", mem_req.address());
-///
-///     // Format of TLP (3DW vs 4DW) is stored in the TLP header
-///     println!("This TLP size is: {}", tlpfmt);
-///     // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
-///     println!("This TLP type is: {:?}", tlp.get_tlp_type());
+///         // Format of TLP (3DW vs 4DW) is stored in the TLP header
+///         println!("This TLP size is: {}", tlpfmt);
+///         // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
+///         println!("This TLP type is: {:?}", tlp.get_tlp_type());
+///     }
 /// }
 /// ```
 pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
 ///     // MemRequest contain only fields specific to PCI Memory Requests
-///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt);
+///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt).unwrap();
 ///
 ///     // Address is 64 bits regardles of TLP format
 ///     //println!("Memory Request Address: {:x}", mem_req.address());
@@ -396,13 +396,13 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 ///     println!("This TLP type is: {:?}", tlp.get_tlp_type());
 /// }
 /// ```
-pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Box<dyn MemRequest> {
+pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
     match format {
-        TlpFmt::NoDataHeader3DW => Box::new(MemRequest3DW(bytes)),
-        TlpFmt::NoDataHeader4DW => Box::new(MemRequest4DW(bytes)),
-        TlpFmt::WithDataHeader3DW => Box::new(MemRequest3DW(bytes)),
-        TlpFmt::WithDataHeader4DW => Box::new(MemRequest4DW(bytes)),
-        TlpFmt::TlpPrefix => Box::new(MemRequest3DW(bytes)),
+        TlpFmt::NoDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
+        TlpFmt::NoDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
+        TlpFmt::WithDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
+        TlpFmt::WithDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
+        TlpFmt::TlpPrefix => Err(TlpError::UnsupportedCombination),
     }
 }
 
@@ -796,7 +796,7 @@ impl TlpPacketHeader {
 ///      TlpType::IOWriteReq |
 ///      TlpType::FetchAddAtomicOpReq |
 ///      TlpType::SwapAtomicOpReq |
-///      TlpType::CompareSwapAtomicOpReq => requester_id = new_mem_req(packet.get_data(), &tlp_format).req_id(),
+///      TlpType::CompareSwapAtomicOpReq => requester_id = new_mem_req(packet.get_data(), &tlp_format).unwrap().req_id(),
 ///      TlpType::ConfType0ReadReq |
 ///      TlpType::ConfType0WriteReq |
 ///      TlpType::ConfType1ReadReq |
@@ -961,6 +961,15 @@ mod tests {
         let result = invalid_combo.get_tlp_type();
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), TlpError::UnsupportedCombination);
+    }
+
+    // ── new_mem_req rejects TlpPrefix ──────────────────────────────────────
+
+    #[test]
+    fn mem_req_rejects_tlp_prefix() {
+        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let result = new_mem_req(bytes, &TlpFmt::TlpPrefix);
+        assert!(matches!(result, Err(TlpError::UnsupportedCombination)));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -1154,7 +1163,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
-        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap());
+        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xABCD);
         assert_eq!(mr.tag(),    0x42);
         assert_eq!(mr.address(), 0xDEAD_0000);
@@ -1172,7 +1181,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
-        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap());
+        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xBEEF);
         assert_eq!(mr.tag(),    0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);
@@ -1237,7 +1246,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
         let fmt = pkt.get_tlp_format().unwrap();
-        let mr = new_mem_req(pkt.get_data(), &fmt);
+        let mr = new_mem_req(pkt.get_data(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0x1234);
         assert_eq!(mr.tag(),     0x56);
         assert_eq!(mr.address(), 0x89AB_CDEF);
@@ -1266,7 +1275,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
         let fmt = pkt.get_tlp_format().unwrap();
-        let mr = new_mem_req(pkt.get_data(), &fmt);
+        let mr = new_mem_req(pkt.get_data(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0xBEEF);
         assert_eq!(mr.tag(),     0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -353,7 +353,7 @@ fn message_request_trait_methods_return_expected_types() {
 fn new_mem_req_factory_exists() {
     let bytes = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let format = TlpFmt::NoDataHeader3DW;
-    let result = new_mem_req(bytes, &format);
+    let result = new_mem_req(bytes, &format).unwrap();
     // Factory returns Box<dyn MemRequest>, verify it has the expected methods
     let _req_id = result.req_id();
     let _addr = result.address();


### PR DESCRIPTION
### Bug

`new_mem_req()` accepted `TlpFmt::TlpPrefix` and silently decoded it as a 3DW memory request. A TLP prefix is not a memory request — it should be rejected.

### Fix

Return type changed from `Box<dyn MemRequest>` to `Result<Box<dyn MemRequest>, TlpError>`. TlpPrefix now yields `Err(TlpError::UnsupportedCombination)`.

**⚠️ Breaking change:** Callers must handle the `Result`.

### Tests added

- `mem_req_rejects_tlp_prefix` — verifies TlpPrefix is rejected

All 103 tests pass. Clippy clean.