### PR TITLE
Fix/new mem req docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let bytes = vec![
     0x00, 0x00, 0x20, 0x0F,   // DW1: req_id=0x0000 tag=0x20 BE=0x0F
     0xF6, 0x20, 0x00, 0x0C,   // DW2: address32=0xF620000C
 ];
-let packet = TlpPacket::new(bytes);
+let packet = TlpPacket::new(bytes).unwrap();
 
 let tlp_type   = packet.get_tlp_type().unwrap();
 let tlp_format = packet.get_tlp_format().unwrap();

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ match tlp_type {
     TlpType::MemReadLockReq |
     TlpType::DeferrableMemWriteReq |
     TlpType::IOReadReq | TlpType::IOWriteReq => {
-        let mr = new_mem_req(packet.get_data(), &tlp_format);
+        let mr = new_mem_req(packet.get_data(), &tlp_format).unwrap();
         println!("req_id=0x{:04X}  tag=0x{:02X}  addr=0x{:X}",
                  mr.req_id(), mr.tag(), mr.address());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,28 +373,32 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// # Examples
 ///
 /// ```
-/// use std::convert::TryFrom;
-///
 /// use rtlp_lib::TlpPacket;
 /// use rtlp_lib::TlpFmt;
+/// use rtlp_lib::TlpError;
 /// use rtlp_lib::MemRequest;
 /// use rtlp_lib::new_mem_req;
 ///
-/// let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/// let tlp = TlpPacket::new(bytes).unwrap();
+/// fn decode(bytes: Vec<u8>) -> Result<(), TlpError> {
+///     let tlp = TlpPacket::new(bytes).unwrap();
 ///
-/// if let Ok(tlpfmt) = tlp.get_tlp_format() {
-///     // MemRequest contain only fields specific to PCI Memory Requests
-///     if let Ok(mem_req) = new_mem_req(tlp.get_data(), &tlpfmt) {
-///         // Address is 64 bits regardles of TLP format
-///         //println!("Memory Request Address: {:x}", mem_req.address());
+///     if let Ok(tlpfmt) = tlp.get_tlp_format() {
+///         // MemRequest contains only fields specific to PCI Memory Requests
+///         let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt)?;
+///
+///         // Address is 64 bits regardless of TLP format
+///         // println!("Memory Request Address: {:x}", mem_req.address());
 ///
 ///         // Format of TLP (3DW vs 4DW) is stored in the TLP header
 ///         println!("This TLP size is: {}", tlpfmt);
 ///         // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
 ///         println!("This TLP type is: {:?}", tlp.get_tlp_type());
 ///     }
+///     Ok(())
 /// }
+///
+/// # let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+/// # let _ = decode(bytes);
 /// ```
 pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
     match format {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,7 +398,7 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 ///
 ///
 /// # let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/// # let _ = decode(bytes);
+/// # decode(bytes).unwrap();
 /// ```
 pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
     match format {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,22 +380,22 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// use rtlp_lib::new_mem_req;
 ///
 /// fn decode(bytes: Vec<u8>) -> Result<(), TlpError> {
-///     let tlp = TlpPacket::new(bytes).unwrap();
+///     let tlp = TlpPacket::new(bytes)?;
 ///
-///     if let Ok(tlpfmt) = tlp.get_tlp_format() {
-///         // MemRequest contains only fields specific to PCI Memory Requests
-///         let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt)?;
+///     let tlpfmt = tlp.get_tlp_format()?;
+///     // MemRequest contains only fields specific to PCI Memory Requests
+///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt)?;
 ///
-///         // Address is 64 bits regardless of TLP format
-///         // println!("Memory Request Address: {:x}", mem_req.address());
+///     // Address is 64 bits regardless of TLP format
+///     // println!("Memory Request Address: {:x}", mem_req.address());
 ///
-///         // Format of TLP (3DW vs 4DW) is stored in the TLP header
-///         println!("This TLP size is: {}", tlpfmt);
-///         // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
-///         println!("This TLP type is: {:?}", tlp.get_tlp_type());
-///     }
+///     // Format of TLP (3DW vs 4DW) is stored in the TLP header
+///     println!("This TLP size is: {}", tlpfmt);
+///     // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
+///     println!("This TLP type is: {:?}", tlp.get_tlp_type());
 ///     Ok(())
 /// }
+///
 ///
 /// # let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 /// # let _ = decode(bytes);

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -353,7 +353,9 @@ fn message_request_trait_methods_return_expected_types() {
 fn new_mem_req_factory_exists() {
     let bytes = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let format = TlpFmt::NoDataHeader3DW;
-    let result = new_mem_req(bytes, &format).unwrap();
+    let result: Result<Box<dyn MemRequest>, TlpError> = new_mem_req(bytes, &format);
+    assert!(result.is_ok());
+    let result = result.unwrap();
     // Factory returns Box<dyn MemRequest>, verify it has the expected methods
     let _req_id = result.req_id();
     let _addr = result.address();


### PR DESCRIPTION
Follow-up to #12: fix docs and test contract for new_mem_req Result return type

PR #12 changed new_mem_req to return Result<Box<dyn MemRequest>, TlpError> but left a few places using the old infallible API pattern.

Changes:

README.md — example was calling new_mem_req without handling Result, would not compile if copied
src/lib.rs — doc example wrapped in a Result-returning function, uses ? for proper error propagation instead of .unwrap()
tests/api_tests.rs — added explicit Result<Box<dyn MemRequest>, TlpError> type annotation to the contract test so the compiler enforces the return type signature