### PR TITLE
Features/non flit mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  fmt:
+    name: Rustfmt
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Check formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: cargo test --verbose
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.85"
+      - name: Build (MSRV)
+        run: cargo build
+      - name: Test (MSRV)
+        run: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to `rtlp_lib` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - Unreleased
+
+### Added
+
+- **Flit-mode (PCIe 6.0+) support** via `TlpMode::Flit` in `TlpPacket::new`.
+  - `FlitTlpType` enum — 13 flit-mode TLP type codes decoded from DW0 byte 0.
+  - `FlitDW0` struct — parsed flit-mode DW0 with `from_dw0()`, `ohc_count()`, `total_bytes()`.
+  - `FlitOhcA` struct — parsed OHC-A extension word with `from_bytes()`.
+  - `FlitStreamWalker` iterator — walks a packed stream of back-to-back flit TLPs.
+  - `TlpError::MissingMandatoryOhc` variant for I/O Write and Config Write missing required OHC.
+  - `FlitDW0::validate_mandatory_ohc()` — enforces mandatory OHC rules for IoWrite and CfgWrite0.
+  - `TlpMode::Flit` variant (PCIe 6.0+).
+
+- **Preferred (non-`get_*`) method names** on public structs (Issue #1):
+  - `TlpPacket::tlp_type()` — replaces `get_tlp_type()`.
+  - `TlpPacket::tlp_format()` — replaces `get_tlp_format()`.
+  - `TlpPacket::flit_type()` — replaces `get_flit_type()`.
+  - `TlpPacket::header()` — replaces `get_header()`.
+  - `TlpPacket::data()` — replaces `get_data()` (returns `&[u8]`, no allocation).
+  - `TlpPacketHeader::tlp_type()` — replaces `get_tlp_type()`.
+
+- **`TlpPacket::mode() -> TlpMode`** — returns the framing mode the packet was created
+  with (`NonFlit` or `Flit`).  The idiomatic way to dispatch between the two API surfaces;
+  more readable than `flit_type().is_some()` as a mode proxy.
+
+- **Factory functions now accept `impl Into<Vec<u8>>`** for `new_conf_req`, `new_cmpl_req`,
+  and `new_msg_req` (previously `Vec<u8>`).  `pkt.data()` (a `&[u8]`) can now be passed
+  directly without a `.to_vec()` allocation at the call site.  `new_mem_req` already
+  accepted `impl Into<Vec<u8>>`; all four functions are now consistent.
+
+- **`TlpType::is_non_posted()`** and **`TlpType::is_posted()`** — classify transactions.
+
+- **Atomic operation support** via `new_atomic_req()`, `AtomicRequest` trait, `AtomicOp`, `AtomicWidth`.
+
+- **Deferrable Memory Write** (`TlpType::DeferrableMemWriteReq`, Fmt=3DW/4DW with data, Type=0b11011).
+
+- **Manual `Debug` implementations** for `TlpPacket` and `TlpPacketHeader` (Issue #3).
+  Fields: `format`, `type`, `tc`, `t9`, `t8`, `attr_b2`, `ln`, `th`, `td`, `ep`, `attr`, `at`, `length`.
+
+- **`#![warn(missing_docs)]`** and **`#![deny(unsafe_code)]`** crate-level attributes.
+
+- **CI workflow** (`.github/workflows/rust.yml`) expanded to four focused jobs:
+  `fmt` (cargo fmt --check), `clippy` (-D warnings), `test`, `msrv` (Rust 1.85).
+
+### Changed
+
+- Twelve internal bitfield accessor methods on `TlpPacketHeader` narrowed from `pub` to
+  `pub(crate)`: `get_format`, `get_type`, `get_t9`, `get_t8`, `get_attr_b2`, `get_ln`,
+  `get_th`, `get_td`, `get_ep`, `get_attr`, `get_at`, `get_length` (Issue #2).
+  `get_tc` remains `pub`.
+
+### Deprecated
+
+- `TlpPacket::get_tlp_type()` — use `tlp_type()` instead.
+- `TlpPacket::get_tlp_format()` — use `tlp_format()` instead.
+- `TlpPacket::get_flit_type()` — use `flit_type()` instead.
+- `TlpPacket::get_header()` — use `header()` instead.
+- `TlpPacket::get_data()` — use `data()` instead (non-allocating `&[u8]`).
+- `TlpPacketHeader::get_tlp_type()` — use `tlp_type()` instead.
+
+### Fixed
+
+- `CompletionReqDW23::laddr()` now correctly returns all 7 bits of the Lower Address field
+  (bit 6 was previously masked out).
+- `MessageReqDW24::dw3()` and `dw4()` now preserve all 32 bits (upper 16 bits were previously
+  truncated due to a `u16` return type in the underlying bitfield).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtlp-lib"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtlp-lib"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtlp-lib"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rtlp-lib = "0.2"
+rtlp-lib = "0.4"
 ```
 
 ## Usage
 
 ```rust
 use rtlp_lib::{
-    TlpPacket, TlpFmt, TlpType,
+    TlpPacket, TlpFmt, TlpType, TlpMode,
     new_mem_req, new_conf_req, new_cmpl_req, new_msg_req, new_atomic_req,
 };
 
@@ -45,7 +45,7 @@ let bytes = vec![
     0x00, 0x00, 0x20, 0x0F,   // DW1: req_id=0x0000 tag=0x20 BE=0x0F
     0xF6, 0x20, 0x00, 0x0C,   // DW2: address32=0xF620000C
 ];
-let packet = TlpPacket::new(bytes).unwrap();
+let packet = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 
 let tlp_type   = packet.get_tlp_type().unwrap();
 let tlp_format = packet.get_tlp_format().unwrap();
@@ -105,9 +105,12 @@ assert!(!TlpType::MemWriteReq.is_non_posted());   // posted
 |---|---|
 | `TlpPacket` | Full packet: DW0 header + remaining data bytes |
 | `TlpPacketHeader` | DW0-only wrapper with accessor methods for every header field |
+| `TlpMode` | Framing mode: `NonFlit` (PCIe 1–5) or `Flit` (PCIe 6.x, stub) |
 | `TlpFmt` | Format enum: `NoDataHeader3DW`, `NoDataHeader4DW`, `WithDataHeader3DW`, `WithDataHeader4DW`, `TlpPrefix` |
-| `TlpType` | 21-variant enum covering all decoded TLP types |
-| `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength` |
+| `TlpType` | 21-variant enum covering all decoded non-flit TLP types |
+| `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength`, `NotImplemented` |
+| `FlitTlpType` | 13-variant enum for PCIe 6.x flit-mode type codes (Tier 1+2) |
+| `FlitDW0` | Parsed flit-mode DW0: `tlp_type`, `tc`, `ohc`, `ts`, `attr`, `length` |
 
 ### Request Traits and Constructors
 
@@ -136,24 +139,29 @@ Every decoding step returns `Result<_, TlpError>`:
 | `InvalidType` | The 5-bit Type field does not match any known encoding |
 | `UnsupportedCombination` | Valid Fmt + Type individually, but not a legal pair (e.g. DMWr with NoData) |
 | `InvalidLength` | Byte slice is too short for the expected header + payload |
+| `NotImplemented` | Feature exists in the API but is not yet implemented (e.g. `TlpMode::Flit`) |
 
 ## Tests
 
-The crate has **102 tests** across four categories:
+The crate has **156 passing tests** (plus 14 `#[ignore]` flit-mode placeholders):
 
-| Category | File | Count |
-|---|---|---|
-| Unit tests | `src/lib.rs` | 30 |
-| API contract tests | `tests/api_tests.rs` | 50 |
-| Integration tests | `tests/tlp_tests.rs` | 16 |
-| Doc tests | `src/lib.rs` | 6 |
+| Category | File | Passes | Ignored |
+|---|---|---|---|
+| Unit tests | `src/lib.rs` | 48 | 0 |
+| API contract tests | `tests/api_tests.rs` | 60 | 0 |
+| Non-flit integration tests | `tests/non_flit_tests.rs` | 16 | 0 |
+| Flit mode tests | `tests/flit_mode_tests.rs` | 26 | 14 |
+| Doc tests | `src/lib.rs` | 6 | 0 |
 
 ```bash
-cargo test            # run all 102 tests
-cargo test --lib      # unit tests only
-cargo test --test tlp_tests   # integration tests only
-cargo test --doc      # doc examples only
+cargo test                        # run all 156 non-ignored tests
+cargo test --lib                  # unit tests only
+cargo test --test non_flit_tests  # non-flit integration tests only
+cargo test --test flit_mode_tests # flit mode Tier 0+1+2 tests
+cargo test --doc                  # doc examples only
 ```
+
+See [TESTS.md](TESTS.md) for the full test structure and flit mode tier descriptions.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -47,40 +47,51 @@ let bytes = vec![
 ];
 let packet = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 
-let tlp_type   = packet.get_tlp_type().unwrap();
-let tlp_format = packet.get_tlp_format().unwrap();
+// mode() tells you which parsing surface to use
+match packet.mode() {
+    TlpMode::NonFlit => {
+        let tlp_type   = packet.tlp_type().unwrap();
+        let tlp_format = packet.tlp_format().unwrap();
 
-match tlp_type {
-    TlpType::MemReadReq | TlpType::MemWriteReq |
-    TlpType::MemReadLockReq |
-    TlpType::DeferrableMemWriteReq |
-    TlpType::IOReadReq | TlpType::IOWriteReq => {
-        let mr = new_mem_req(packet.get_data(), &tlp_format).unwrap();
-        println!("req_id=0x{:04X}  tag=0x{:02X}  addr=0x{:X}",
-                 mr.req_id(), mr.tag(), mr.address());
+        match tlp_type {
+            TlpType::MemReadReq | TlpType::MemWriteReq |
+            TlpType::MemReadLockReq |
+            TlpType::DeferrableMemWriteReq |
+            TlpType::IOReadReq | TlpType::IOWriteReq => {
+                // data() returns &[u8] — no allocation, passes directly to new_mem_req
+                let mr = new_mem_req(packet.data(), &tlp_format).unwrap();
+                println!("req_id=0x{:04X}  tag=0x{:02X}  addr=0x{:X}",
+                         mr.req_id(), mr.tag(), mr.address());
+            }
+            TlpType::FetchAddAtomicOpReq |
+            TlpType::SwapAtomicOpReq |
+            TlpType::CompareSwapAtomicOpReq => {
+                let ar = new_atomic_req(&packet).unwrap();
+                println!("atomic {:?} operand0=0x{:X}", ar.op(), ar.operand0());
+            }
+            TlpType::ConfType0ReadReq | TlpType::ConfType0WriteReq |
+            TlpType::ConfType1ReadReq | TlpType::ConfType1WriteReq => {
+                let cr = new_conf_req(packet.data());  // accepts &[u8] directly
+                println!("config bus={} dev={} func={}",
+                         cr.bus_nr(), cr.dev_nr(), cr.func_nr());
+            }
+            TlpType::Cpl | TlpType::CplData |
+            TlpType::CplLocked | TlpType::CplDataLocked => {
+                let cpl = new_cmpl_req(packet.data());
+                println!("completion status={}", cpl.cmpl_stat());
+            }
+            TlpType::MsgReq | TlpType::MsgReqData => {
+                let msg = new_msg_req(packet.data());
+                println!("message code=0x{:02X}", msg.msg_code());
+            }
+            _ => println!("TLP type: {:?}", tlp_type),
+        }
     }
-    TlpType::FetchAddAtomicOpReq |
-    TlpType::SwapAtomicOpReq |
-    TlpType::CompareSwapAtomicOpReq => {
-        let ar = new_atomic_req(&packet).unwrap();
-        println!("atomic {:?} operand0=0x{:X}", ar.op(), ar.operand0());
+    TlpMode::Flit => {
+        // Use flit_type() for flit-mode packets
+        println!("flit type: {:?}", packet.flit_type());
     }
-    TlpType::ConfType0ReadReq | TlpType::ConfType0WriteReq |
-    TlpType::ConfType1ReadReq | TlpType::ConfType1WriteReq => {
-        let cr = new_conf_req(packet.get_data(), &tlp_format);
-        println!("config bus={} dev={} func={}",
-                 cr.bus_nr(), cr.dev_nr(), cr.func_nr());
-    }
-    TlpType::Cpl | TlpType::CplData |
-    TlpType::CplLocked | TlpType::CplDataLocked => {
-        let cpl = new_cmpl_req(packet.get_data(), &tlp_format);
-        println!("completion status={}", cpl.cmpl_stat());
-    }
-    TlpType::MsgReq | TlpType::MsgReqData => {
-        let msg = new_msg_req(packet.get_data(), &tlp_format);
-        println!("message code=0x{:02X}", msg.msg_code());
-    }
-    _ => println!("TLP type: {:?}", tlp_type),
+    _ => {}
 }
 ```
 
@@ -106,6 +117,22 @@ assert!(!TlpType::MemWriteReq.is_non_posted());   // posted
 | `TlpPacket` | Full packet: DW0 header + remaining data bytes |
 | `TlpPacketHeader` | DW0-only wrapper with accessor methods for every header field |
 | `TlpMode` | Framing mode: `NonFlit` (PCIe 1–5) or `Flit` (PCIe 6.x) |
+
+**Key `TlpPacket` methods:**
+
+| Method | Returns | Notes |
+|---|---|---|
+| `mode()` | `TlpMode` | Explicit framing mode; use to dispatch between API surfaces |
+| `tlp_type()` | `Result<TlpType, TlpError>` | Non-flit only; returns `Err(NotImplemented)` for flit |
+| `tlp_format()` | `Result<TlpFmt, TlpError>` | Non-flit only |
+| `flit_type()` | `Option<FlitTlpType>` | Flit only; `None` for non-flit |
+| `header()` | `&TlpPacketHeader` | Non-flit only (returns dummy zeros for flit) |
+| `data()` | `&[u8]` | Payload bytes after DW0; borrows from the packet |
+
+**Other core types:**
+
+| Type | Description |
+|---|---|
 | `TlpFmt` | Format enum: `NoDataHeader3DW`, `NoDataHeader4DW`, `WithDataHeader3DW`, `WithDataHeader4DW`, `TlpPrefix` |
 | `TlpType` | 21-variant enum covering all decoded non-flit TLP types |
 | `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength`, `NotImplemented`, `MissingMandatoryOhc` |
@@ -125,7 +152,8 @@ use rtlp_lib::{TlpPacket, TlpMode, FlitStreamWalker, FlitTlpType};
 // Parse a single flit TLP
 let nop_bytes = vec![0x00u8, 0x00, 0x00, 0x00];
 let pkt = TlpPacket::new(nop_bytes, TlpMode::Flit).unwrap();
-assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+assert_eq!(pkt.flit_type(), Some(FlitTlpType::Nop));
+assert_eq!(pkt.mode(), TlpMode::Flit);  // explicit mode check
 
 // Walk a packed stream of back-to-back flit TLPs
 let stream: &[u8] = &[/* packed bytes */];
@@ -140,10 +168,13 @@ for result in FlitStreamWalker::new(stream) {
 | Trait | Fields | Constructor |
 |---|---|---|
 | `MemRequest` | `address()`, `req_id()`, `tag()`, `ldwbe()`, `fdwbe()` | `new_mem_req(bytes, &fmt)` |
-| `ConfigurationRequest` | `req_id()`, `tag()`, `bus_nr()`, `dev_nr()`, `func_nr()`, `ext_reg_nr()`, `reg_nr()` | `new_conf_req(bytes, &fmt)` |
-| `CompletionRequest` | `cmpl_id()`, `cmpl_stat()`, `bcm()`, `byte_cnt()`, `req_id()`, `tag()`, `laddr()` | `new_cmpl_req(bytes, &fmt)` |
-| `MessageRequest` | `req_id()`, `tag()`, `msg_code()`, `dw3()`, `dw4()` | `new_msg_req(bytes, &fmt)` |
+| `ConfigurationRequest` | `req_id()`, `tag()`, `bus_nr()`, `dev_nr()`, `func_nr()`, `ext_reg_nr()`, `reg_nr()` | `new_conf_req(bytes)` |
+| `CompletionRequest` | `cmpl_id()`, `cmpl_stat()`, `bcm()`, `byte_cnt()`, `req_id()`, `tag()`, `laddr()` | `new_cmpl_req(bytes)` |
+| `MessageRequest` | `req_id()`, `tag()`, `msg_code()`, `dw3()`, `dw4()` | `new_msg_req(bytes)` |
 | `AtomicRequest` | `op()`, `width()`, `req_id()`, `tag()`, `address()`, `operand0()`, `operand1()` | `new_atomic_req(&pkt)` |
+
+> **Note:** All `bytes` parameters accept `impl Into<Vec<u8>>` — you can pass `pkt.data()` (`&[u8]`)
+> directly without calling `.to_vec()`. Only `new_mem_req` additionally requires `&TlpFmt`.
 
 ### Atomic-Specific Types
 
@@ -167,18 +198,18 @@ Every decoding step returns `Result<_, TlpError>`:
 
 ## Tests
 
-The crate has **180 passing tests** (0 ignored):
+The crate has **212 passing tests** (0 ignored):
 
 | Category | File | Passes | Ignored |
 |---|---|---|---|
-| Unit tests | `src/lib.rs` | 51 | 0 |
-| API contract tests | `tests/api_tests.rs` | 64 | 0 |
-| Non-flit integration tests | `tests/non_flit_tests.rs` | 16 | 0 |
-| Flit mode tests | `tests/flit_mode_tests.rs` | 42 | 0 |
-| Doc tests | `src/lib.rs` | 7 | 0 |
+| Unit tests | `src/lib.rs` | 56 | 0 |
+| API contract tests | `tests/api_tests.rs` | 77 | 0 |
+| Non-flit integration tests | `tests/non_flit_tests.rs` | 25 | 0 |
+| Flit mode tests | `tests/flit_mode_tests.rs` | 45 | 0 |
+| Doc tests | `src/lib.rs` | 9 | 0 |
 
 ```bash
-cargo test                        # run all 180 tests
+cargo test                        # run all 212 tests
 cargo test --lib                  # unit tests only
 cargo test --test non_flit_tests  # non-flit integration tests only
 cargo test --test flit_mode_tests # flit mode tests (all tiers)
@@ -189,9 +220,14 @@ See [TESTS.md](TESTS.md) for the full test structure and flit mode tier descript
 
 ## Documentation
 
-The documentation of the released version is available on
-[docs.rs](https://docs.rs/rtlp-lib).
-To generate current documentation locally: `cargo doc --open`
+- **[docs/api_guide.md](docs/api_guide.md)** — user-facing guide: parsing flow,
+  mode dispatch, ownership/lifetimes, error handling, deprecated-API migration,
+  and how to test your own code against the library.
+- **[TESTS.md](TESTS.md)** — test structure, tier descriptions, FM_* byte-vector
+  constants reference, and running individual test suites.
+- **[tlp.md](tlp.md)** — PCIe TLP encoding reference with byte-level examples.
+- **[docs.rs](https://docs.rs/rtlp-lib)** — published rustdoc for the released version.
+- `cargo doc --open` — rustdoc for the current local build.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rtlp-lib = "0.4"
+rtlp-lib = "0.5"
 ```
 
 ## Usage
@@ -99,18 +99,41 @@ assert!(!TlpType::MemWriteReq.is_non_posted());   // posted
 
 ## Public API Overview
 
-### Core Types
+### Core Types (Non-Flit)
 
 | Type | Description |
 |---|---|
 | `TlpPacket` | Full packet: DW0 header + remaining data bytes |
 | `TlpPacketHeader` | DW0-only wrapper with accessor methods for every header field |
-| `TlpMode` | Framing mode: `NonFlit` (PCIe 1–5) or `Flit` (PCIe 6.x, stub) |
+| `TlpMode` | Framing mode: `NonFlit` (PCIe 1–5) or `Flit` (PCIe 6.x) |
 | `TlpFmt` | Format enum: `NoDataHeader3DW`, `NoDataHeader4DW`, `WithDataHeader3DW`, `WithDataHeader4DW`, `TlpPrefix` |
 | `TlpType` | 21-variant enum covering all decoded non-flit TLP types |
-| `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength`, `NotImplemented` |
-| `FlitTlpType` | 13-variant enum for PCIe 6.x flit-mode type codes (Tier 1+2) |
-| `FlitDW0` | Parsed flit-mode DW0: `tlp_type`, `tc`, `ohc`, `ts`, `attr`, `length` |
+| `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength`, `NotImplemented`, `MissingMandatoryOhc` |
+
+### Flit Mode Types (PCIe 6.x)
+
+| Type | Description |
+|---|---|
+| `FlitTlpType` | 13-variant enum for flit-mode type codes (`TryFrom<u8>`, `base_header_dw()`, `is_read_request()`) |
+| `FlitDW0` | Parsed flit-mode DW0: `tlp_type`, `tc`, `ohc`, `ts`, `attr`, `length`; `from_dw0()`, `total_bytes()` |
+| `FlitOhcA` | Parsed OHC-A word: `pasid`, `fdwbe`, `ldwbe`; `from_bytes()` |
+| `FlitStreamWalker` | Iterator over a packed flit TLP byte stream; yields `(offset, FlitTlpType, size)` per TLP |
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, FlitStreamWalker, FlitTlpType};
+
+// Parse a single flit TLP
+let nop_bytes = vec![0x00u8, 0x00, 0x00, 0x00];
+let pkt = TlpPacket::new(nop_bytes, TlpMode::Flit).unwrap();
+assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+
+// Walk a packed stream of back-to-back flit TLPs
+let stream: &[u8] = &[/* packed bytes */];
+for result in FlitStreamWalker::new(stream) {
+    let (offset, typ, size) = result.unwrap();
+    println!("TLP at offset {}: {:?} ({} bytes)", offset, typ, size);
+}
+```
 
 ### Request Traits and Constructors
 
@@ -139,25 +162,26 @@ Every decoding step returns `Result<_, TlpError>`:
 | `InvalidType` | The 5-bit Type field does not match any known encoding |
 | `UnsupportedCombination` | Valid Fmt + Type individually, but not a legal pair (e.g. DMWr with NoData) |
 | `InvalidLength` | Byte slice is too short for the expected header + payload |
-| `NotImplemented` | Feature exists in the API but is not yet implemented (e.g. `TlpMode::Flit`) |
+| `NotImplemented` | Feature exists in the API but is not yet implemented (e.g. `TlpPacketHeader::new` with `Flit`) |
+| `MissingMandatoryOhc` | Flit TLP type requires an OHC word that was absent (IOWr/CfgWr) |
 
 ## Tests
 
-The crate has **156 passing tests** (plus 14 `#[ignore]` flit-mode placeholders):
+The crate has **180 passing tests** (0 ignored):
 
 | Category | File | Passes | Ignored |
 |---|---|---|---|
-| Unit tests | `src/lib.rs` | 48 | 0 |
-| API contract tests | `tests/api_tests.rs` | 60 | 0 |
+| Unit tests | `src/lib.rs` | 51 | 0 |
+| API contract tests | `tests/api_tests.rs` | 64 | 0 |
 | Non-flit integration tests | `tests/non_flit_tests.rs` | 16 | 0 |
-| Flit mode tests | `tests/flit_mode_tests.rs` | 26 | 14 |
-| Doc tests | `src/lib.rs` | 6 | 0 |
+| Flit mode tests | `tests/flit_mode_tests.rs` | 42 | 0 |
+| Doc tests | `src/lib.rs` | 7 | 0 |
 
 ```bash
-cargo test                        # run all 156 non-ignored tests
+cargo test                        # run all 180 tests
 cargo test --lib                  # unit tests only
 cargo test --test non_flit_tests  # non-flit integration tests only
-cargo test --test flit_mode_tests # flit mode Tier 0+1+2 tests
+cargo test --test flit_mode_tests # flit mode tests (all tiers)
 cargo test --doc                  # doc examples only
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -12,7 +12,7 @@ This document describes the test structure for the rtlp-lib crate.
 
 **Location:** `#[cfg(test)] mod tests` inside `src/lib.rs`
 
-**Test count: 48**
+**Test count: 51**
 
 Categories:
 - `TlpHeader` bitfield parsing (all-zeros, all-ones, bit-position verification)
@@ -91,7 +91,7 @@ Categories:
 
 **Purpose:** Test plan and byte-vector constants for PCIe 6.x flit mode TLP parsing.
 
-**Test count: 40 total (32 passing, 8 `#[ignore]`)**
+**Test count: 42 total (42 passing, 0 `#[ignore]`)**
 
 #### Tier 0 — Current stubs ✅ (5 tests — permanent regression guards)
 
@@ -163,15 +163,14 @@ Tests embedded in `src/lib.rs` doc comments:
 
 | Test Type | Location | Passes | Ignored | Purpose |
 |---|---|---|---|---|
-| Unit Tests | `src/lib.rs` | 48 | 0 | Internal implementation |
+| Unit Tests | `src/lib.rs` | 51 | 0 | Internal implementation |
 | Non-Flit Integration | `tests/non_flit_tests.rs` | 16 | 0 | PCIe 1–5 functional behavior |
 | API Contract | `tests/api_tests.rs` | 64 | 0 | Public API stability |
-| Flit Mode | `tests/flit_mode_tests.rs` | 32 | 8 | PCIe 6.x test plan |
-| Doc Tests | `src/lib.rs` | 6 | 0 | Documentation examples |
-| **Total** | | **166** | **8** | |
+| Flit Mode | `tests/flit_mode_tests.rs` | 42 | 0 | PCIe 6.x -- all tiers implemented |
+| Doc Tests | `src/lib.rs` | 7 | 0 | Documentation examples |
+| **Total** | | **180** | **0** | |
 
-> `#[ignore]` tests compile but do not run by default.  
-> Run `cargo test -- --ignored` to see all pending flit mode tests (Tier 4–5).
+> All flit mode tiers (0–5) are implemented. Zero `#[ignore]` tests remain.
 
 ---
 
@@ -214,19 +213,18 @@ cargo test -- --nocapture
 2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
 3. **Incremental Plan** — flit mode tiers unlock as implementation lands
 4. **Documentation** — `#[ignore]` test bodies describe exactly what to implement
-5. **Always Green** — all 166 non-ignored tests pass at every commit
+5. **Always Green** — all 180 tests pass at every commit (0 ignored)
 
 ---
 
-## Future Work (Flit Mode Implementation)
+## Flit Mode Implementation Status (v0.5.0)
 
-To remove `#[ignore]` from flit mode tests, implement in order:
+All tiers complete -- no `#[ignore]` tests remain:
 
-1. ~~**Tier 1** — `FlitDW0` struct + `flit_dw0_from_bytes()`~~ ✅ Done (v0.4.1)
-2. ~~**Tier 2** — `FlitTlpType` enum + base header size table~~ ✅ Done (v0.4.1)
-3. ~~**Tier 3** — `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`~~ ✅ Done (v0.4.1)
-4. **Tier 4** — `FlitStreamWalker` iterator
-5. **Tier 5** — Wire `TlpMode::Flit` in `TlpPacket::new`
-6. Bump version to `0.5.0`
+1. ~~**Tier 1** — `FlitDW0` struct + `from_dw0()`~~ ✅ Done (v0.4.1)
+2. ~~**Tier 2** — `FlitTlpType` enum + `base_header_dw()` + `total_bytes()`~~ ✅ Done (v0.4.1)
+3. ~~**Tier 3** — `FlitOhcA` + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`~~ ✅ Done (v0.4.1)
+4. ~~**Tier 4** — `FlitStreamWalker` iterator~~ ✅ Done (v0.5.0)
+5. ~~**Tier 5** — `TlpPacket::new_flit()` + `get_flit_type()`~~ ✅ Done (v0.5.0)
 
 See `docs/flit_mode_test_plan.md` for full architectural decisions and acceptance criteria.

--- a/TESTS.md
+++ b/TESTS.md
@@ -64,7 +64,7 @@ All calls pass `TlpMode::NonFlit` explicitly.
 **Purpose:** Ensure the public API remains stable and catch breaking changes.  
 Mode-agnostic — tests API surface only, not behavior.
 
-**Test count: 55**
+**Test count: 60**
 
 Categories:
 - `TlpError` enum — all variants including `NotImplemented`, Debug, PartialEq
@@ -91,9 +91,9 @@ Categories:
 
 **Purpose:** Test plan and byte-vector constants for PCIe 6.x flit mode TLP parsing.
 
-**Test count: 30 total (5 passing, 25 `#[ignore]`)**
+**Test count: 40 total (26 passing, 14 `#[ignore]`)**
 
-#### Tier 0 — Current stubs ✅ (5 tests, all pass today)
+#### Tier 0 — Current stubs ✅ (5 tests — permanent regression guards)
 
 | Test | What it checks |
 |---|---|
@@ -103,14 +103,14 @@ Categories:
 | `flit_dw0_type_bytes_are_correct` | Byte 0 of each vector matches expected type code |
 | `flit_dw0_ohc_bytes_are_correct` | Byte 1 OHC field matches expected flags |
 
-#### Tier 1 — DW0 field extraction `#[ignore]` (6 tests)
-Unlock: `FlitDW0` struct + `flit_dw0_from_bytes()` in `src/lib.rs`
+#### Tier 1 — DW0 field extraction ✅ (8 tests — implemented)
+Implemented: `FlitDW0::from_dw0()` in `src/lib.rs`
 
-#### Tier 2 — Per-vector header + size validation `#[ignore]` (11 tests)
-Unlock: `FlitTlpType` enum + type-to-header-size table in `src/lib.rs`
+#### Tier 2 — Per-vector header + size validation ✅ (13 tests — implemented)
+Implemented: `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` in `src/lib.rs`
 
 #### Tier 3 — OHC field parsing and mandatory-OHC validation `#[ignore]` (6 tests)
-Unlock: OHC parser + `TlpError::MissingMandatoryOhc` variant
+Unlock: `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
 
 #### Tier 4 — Packed stream walking `#[ignore]` (2 tests)
 Unlock: `FlitStreamWalker` iterator in `src/lib.rs`
@@ -165,13 +165,13 @@ Tests embedded in `src/lib.rs` doc comments:
 |---|---|---|---|---|
 | Unit Tests | `src/lib.rs` | 48 | 0 | Internal implementation |
 | Non-Flit Integration | `tests/non_flit_tests.rs` | 16 | 0 | PCIe 1–5 functional behavior |
-| API Contract | `tests/api_tests.rs` | 55 | 0 | Public API stability |
-| Flit Mode | `tests/flit_mode_tests.rs` | 5 | 25 | PCIe 6.x test plan |
+| API Contract | `tests/api_tests.rs` | 60 | 0 | Public API stability |
+| Flit Mode | `tests/flit_mode_tests.rs` | 26 | 14 | PCIe 6.x test plan |
 | Doc Tests | `src/lib.rs` | 6 | 0 | Documentation examples |
-| **Total** | | **130** | **25** | |
+| **Total** | | **156** | **14** | |
 
 > `#[ignore]` tests compile but do not run by default.  
-> Run `cargo test -- --ignored` to see all pending flit mode tests.
+> Run `cargo test -- --ignored` to see all pending flit mode tests (Tier 3–5).
 
 ---
 
@@ -214,7 +214,7 @@ cargo test -- --nocapture
 2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
 3. **Incremental Plan** — flit mode tiers unlock as implementation lands
 4. **Documentation** — `#[ignore]` test bodies describe exactly what to implement
-5. **Always Green** — all 130 non-ignored tests pass at every commit
+5. **Always Green** — all 156 non-ignored tests pass at every commit
 
 ---
 
@@ -222,9 +222,9 @@ cargo test -- --nocapture
 
 To remove `#[ignore]` from flit mode tests, implement in order:
 
-1. **Tier 1** — `FlitDW0` struct + `flit_dw0_from_bytes()`
-2. **Tier 2** — `FlitTlpType` enum + base header size table
-3. **Tier 3** — OHC parser + `TlpError::MissingMandatoryOhc`
+1. ~~**Tier 1** — `FlitDW0` struct + `flit_dw0_from_bytes()`~~ ✅ Done (v0.4.1)
+2. ~~**Tier 2** — `FlitTlpType` enum + base header size table~~ ✅ Done (v0.4.1)
+3. **Tier 3** — `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
 4. **Tier 4** — `FlitStreamWalker` iterator
 5. **Tier 5** — Wire `TlpMode::Flit` in `TlpPacket::new`
 6. Bump version to `0.5.0`

--- a/TESTS.md
+++ b/TESTS.md
@@ -12,12 +12,13 @@ This document describes the test structure for the rtlp-lib crate.
 
 **Location:** `#[cfg(test)] mod tests` inside `src/lib.rs`
 
-**Test count: 51**
+**Test count: 52**
 
 Categories:
 - `TlpHeader` bitfield parsing (all-zeros, all-ones, bit-position verification)
-- TLP type decoding — every supported (fmt, type) pair
+- TLP type decoding — every supported (fmt, type) pair, including all 12 message routing sub-types and TLP prefix variants
 - Unsupported / invalid combination error paths
+- Invalid format values (all three reserved Fmt values: 0b101, 0b110, 0b111)
 - DMWr (Deferrable Memory Write) header decode
 - Atomic operand parsing via `new_atomic_req()`
 - Completion lower-address field decode
@@ -25,6 +26,7 @@ Categories:
 - `TlpMode::Flit` stub — returns `NotImplemented`
 - `TlpError::NotImplemented` distinctness
 - `TlpMode` derive traits (Debug, Clone, Copy, PartialEq)
+- `is_non_posted()` exhaustive coverage — all 21 `TlpType` variants
 
 **Why separate:** These tests use `TlpHeader` which is an internal implementation detail, not part of the public API.
 
@@ -34,10 +36,10 @@ Categories:
 
 **Purpose:** Functional behavior of the library through the public API using `TlpMode::NonFlit` (PCIe 1.0–5.0).
 
-**Test count: 16**
+**Test count: 25**
 
 Tests:
-- `test_tlp_packet` — basic TLP packet parsing
+- `test_tlp_packet` — structural split test (note: Config Read with extra bytes is intentional)
 - `test_complreq_trait` — completion request trait fields
 - `test_configreq_trait` — configuration request trait fields
 - `is_memreq_tag_works` — tag extraction (3DW and 4DW)
@@ -53,6 +55,15 @@ Tests:
 - `dmwr64_decode_via_tlppacket` — DMWr 4DW decode
 - `dmwr_rejects_nodata_formats` — DMWr negative test
 - `dmwr_is_non_posted` — non-posted predicate
+- `msg_req_decode_route_to_rc_3dw_no_data` — Message TLP decode (was previously broken)
+- `msg_req_data_decode_route_to_rc_3dw_with_data` — MsgReqData decode
+- `msg_req_all_six_routing_subtypes_decode` — all 6 PCIe message routing codes
+- `msg_req_data_all_six_routing_subtypes_decode` — all 6 routing codes with data
+- `msg_req_end_to_end_path_with_new_msg_req` — full packet → field extraction
+- `local_tlp_prefix_decode_type4_zero` — TLP Prefix decode (was previously broken)
+- `end_to_end_tlp_prefix_decode_type4_one` — EndToEndTlpPrefix decode
+- `tlp_prefix_local_and_end_to_end_distinguished_by_bit4` — Type[4] discrimination
+- `prefix_types_are_not_non_posted` — Prefix is_non_posted() = false
 
 **Why separate:** These verify end-to-end non-flit functionality that users rely on.  
 All calls pass `TlpMode::NonFlit` explicitly.
@@ -64,15 +75,15 @@ All calls pass `TlpMode::NonFlit` explicitly.
 **Purpose:** Ensure the public API remains stable and catch breaking changes.  
 Mode-agnostic — tests API surface only, not behavior.
 
-**Test count: 64**
+**Test count: 67**
 
 Categories:
-- `TlpError` enum — all variants including `NotImplemented`, Debug, PartialEq
+- `TlpError` enum — all variants including `NotImplemented`, `MissingMandatoryOhc`, Display, PartialEq, `std::error::Error`
 - `TlpMode` enum — NonFlit and Flit variants, Copy/Clone/Debug/PartialEq
-- `TlpMode::Flit` stub — returns `NotImplemented` for Packet and Header
+- `TlpMode::Flit` — now implemented for `TlpPacket::new()`; `TlpPacketHeader::new()` still returns `NotImplemented`
 - `TlpFmt` enum — all variants, `TryFrom<u32>` valid and invalid values
 - `TlpType` enum — all 21 variants, Debug, PartialEq
-- `TlpPacket` — constructor, getters, error conditions
+- `TlpPacket` — constructor, `get_tlp_type()`, `get_tlp_format()`, `data()` (new), `get_data()` (deprecated, backward-compat)
 - `TlpPacketHeader` — constructor, `get_tlp_type()`
 - `MemRequest` trait — 3DW and 4DW struct accessibility and method types
 - `ConfigurationRequest` trait — struct and method types
@@ -82,6 +93,7 @@ Categories:
 - Factory functions — `new_mem_req`, `new_conf_req`, `new_cmpl_req`, `new_msg_req`, `new_atomic_req`
 - API stability compilation test — all public types and functions
 - Edge cases — minimum size, empty data, payload preservation
+- `tlp_packet_data_method_exists` — verifies the new `data()` API
 
 **Why separate:** These serve as a living contract specification. A failure indicates a breaking API change.
 
@@ -91,32 +103,35 @@ Categories:
 
 **Purpose:** Test plan and byte-vector constants for PCIe 6.x flit mode TLP parsing.
 
-**Test count: 42 total (42 passing, 0 `#[ignore]`)**
+**Test count: 45 total (45 passing, 0 `#[ignore]`)**
 
-#### Tier 0 — Current stubs ✅ (5 tests — permanent regression guards)
+#### Tier 0 — Regression guards (3 tests)
 
 | Test | What it checks |
 |---|---|
-| `flit_packet_new_returns_not_implemented` | `TlpMode::Flit` → `NotImplemented` |
-| `flit_header_new_returns_not_implemented` | Same for `TlpPacketHeader` |
-| `flit_byte_vectors_have_correct_sizes` | 16 FM_* constants have correct byte lengths |
-| `flit_dw0_type_bytes_are_correct` | Byte 0 of each vector matches expected type code |
-| `flit_dw0_ohc_bytes_are_correct` | Byte 1 OHC field matches expected flags |
+| `flit_packet_new_succeeds_for_valid_flit` | `TlpMode::Flit` decodes MRd32 correctly |
+| `flit_header_new_returns_not_implemented` | `TlpPacketHeader::new(Flit)` → `NotImplemented` |
+| `flit_all_fm_vectors_parse_to_expected_type` | **Parser-driven**: every FM_* constant decodes to the expected `FlitTlpType` (catches spec errors in byte vectors) |
+| `flit_all_fm_vectors_parse_with_correct_ohc` | **Parser-driven**: every FM_* OHC bitmap decodes correctly |
 
 #### Tier 1 — DW0 field extraction ✅ (8 tests — implemented)
 Implemented: `FlitDW0::from_dw0()` in `src/lib.rs`
 
-#### Tier 2 — Per-vector header + size validation ✅ (13 tests — implemented)
-Implemented: `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` in `src/lib.rs`
+#### Tier 2 — Per-vector header + size validation ✅ (15 tests — implemented)
+Implemented: `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` + `has_data_payload()` in `src/lib.rs`
+
+Includes `flit_t2_total_bytes_length_zero_encodes_1024dw` — verifies PCIe spec rule that `Length=0` encodes 1024 DW.
 
 #### Tier 3 — OHC field parsing and mandatory-OHC validation ✅ (6 tests — implemented)
 Implemented: `FlitOhcA::from_bytes()` + `FlitDW0::validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
 
-#### Tier 4 — Packed stream walking `#[ignore]` (2 tests)
-Unlock: `FlitStreamWalker` iterator in `src/lib.rs`
+#### Tier 4 — Packed stream walking ✅ (3 tests — implemented)
+Implemented: `FlitStreamWalker` iterator in `src/lib.rs`
 
-#### Tier 5 — End-to-end `TlpMode::Flit` pipeline `#[ignore]` (6 tests)
-Unlock: `TlpPacket::new_flit()` fully wired
+#### Tier 5 — End-to-end `TlpMode::Flit` pipeline ✅ (10 tests — implemented)
+Implemented: `TlpPacket::new_flit()` + `get_flit_type()`
+
+Includes atomic operand-value verification for `FM_FETCHADD32` (operand=0x01000000) and `FM_CAS32` (compare=0x11111111, swap=0x22222222).
 
 **FM_* byte vector constants (all defined in this file):**
 
@@ -124,17 +139,17 @@ Unlock: `TlpPacket::new_flit()` fully wired
 |---|---|---|
 | `FM_NOP` | 4 | Flit NOP (type 0x00) |
 | `FM_MRD32_MIN` | 12 | MRd32, minimal, no OHC |
-| `FM_MRD32_A1_PASID` | 16 | MRd32 + OHC-A1 (PASID) |
+| `FM_MRD32_A1_PASID` | 16 | MRd32 + OHC-A1 (PASID=0x12345) |
 | `FM_MWR32_MIN` | 16 | MWr32, minimal, no OHC |
-| `FM_MWR32_PARTIAL_A1` | 20 | MWr32 + OHC-A1 (partial BE) |
-| `FM_IOWR_A2` | 20 | IOWr + mandatory OHC-A2 |
-| `FM_CFGWR0_A3` | 20 | CfgWr0 + mandatory OHC-A3 |
+| `FM_MWR32_PARTIAL_A1` | 20 | MWr32 + OHC-A1 (partial BE fdwbe=0x3) |
+| `FM_IOWR_A2` | 20 | IOWr + mandatory OHC-A2 (fdwbe=0xF) |
+| `FM_CFGWR0_A3` | 20 | CfgWr0 + mandatory OHC-A3 (fdwbe=0xF) |
 | `FM_UIOMRD64_MIN` | 16 | UIOMRd 4DW header, no OHC |
 | `FM_UIOMWR64_MIN` | 24 | UIOMWr 4DW header + 2DW payload |
 | `FM_MSG_TO_RC` | 12 | Message routed to RC, no data |
 | `FM_MSGD_TO_RC` | 16 | Message with data routed to RC |
-| `FM_FETCHADD32` | 16 | FetchAdd 32-bit atomic |
-| `FM_CAS32` | 20 | CAS 32-bit atomic |
+| `FM_FETCHADD32` | 16 | FetchAdd 32-bit atomic, operand=0x01000000 |
+| `FM_CAS32` | 20 | CAS 32-bit atomic, compare=0x11111111 swap=0x22222222 |
 | `FM_DMWR32` | 16 | DMWr 32-bit |
 | `FM_STREAM_FRAGMENT_0` | 48 | 4 back-to-back TLPs |
 | `FM_LOCAL_PREFIX_ONLY` | 4 | Local TLP Prefix token |
@@ -147,15 +162,16 @@ For design rationale see `docs/flit_mode_test_plan.md`.
 
 **Purpose:** Ensure examples in doc comments compile and run correctly.
 
-**Test count: 6**
+**Test count: 7**
 
 Tests embedded in `src/lib.rs` doc comments:
 - `TlpPacket` usage example
 - `new_mem_req` usage example
-- `new_conf_req` usage example
+- `new_conf_req` usage example (updated: 12-byte input, uses `data().to_vec()`)
 - `new_cmpl_req` usage example
 - `new_msg_req` usage example
 - `new_atomic_req` usage example
+- `FlitStreamWalker` usage example
 
 ---
 
@@ -163,12 +179,12 @@ Tests embedded in `src/lib.rs` doc comments:
 
 | Test Type | Location | Passes | Ignored | Purpose |
 |---|---|---|---|---|
-| Unit Tests | `src/lib.rs` | 51 | 0 | Internal implementation |
-| Non-Flit Integration | `tests/non_flit_tests.rs` | 16 | 0 | PCIe 1–5 functional behavior |
-| API Contract | `tests/api_tests.rs` | 64 | 0 | Public API stability |
-| Flit Mode | `tests/flit_mode_tests.rs` | 42 | 0 | PCIe 6.x -- all tiers implemented |
+| Unit Tests | `src/lib.rs` | 52 | 0 | Internal implementation |
+| Non-Flit Integration | `tests/non_flit_tests.rs` | 25 | 0 | PCIe 1–5 functional behavior |
+| API Contract | `tests/api_tests.rs` | 67 | 0 | Public API stability |
+| Flit Mode | `tests/flit_mode_tests.rs` | 45 | 0 | PCIe 6.x — all tiers implemented |
 | Doc Tests | `src/lib.rs` | 7 | 0 | Documentation examples |
-| **Total** | | **180** | **0** | |
+| **Total** | | **196** | **0** | |
 
 > All flit mode tiers (0–5) are implemented. Zero `#[ignore]` tests remain.
 
@@ -183,14 +199,8 @@ cargo test
 # Run only non-flit integration tests
 cargo test --test non_flit_tests
 
-# Run only flit mode tests (Tier 0 only — rest ignored)
+# Run only flit mode tests
 cargo test --test flit_mode_tests
-
-# Run only flit mode Tier 0 stubs
-cargo test --test flit_mode_tests flit_packet
-
-# See all pending flit mode tests (will show as 'FAILED - panicked at todo!')
-cargo test --test flit_mode_tests -- --ignored
 
 # Run only API contract tests
 cargo test --test api_tests
@@ -211,18 +221,18 @@ cargo test -- --nocapture
 
 1. **Breaking Change Detection** — `api_tests.rs` fails if the public interface changes
 2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
-3. **Incremental Plan** — flit mode tiers unlock as implementation lands
-4. **Documentation** — `#[ignore]` test bodies describe exactly what to implement
-5. **Always Green** — all 180 tests pass at every commit (0 ignored)
+3. **Incremental Plan** — flit mode tiers document implementation history
+4. **Parser-Driven Vector Tests** — `flit_all_fm_vectors_parse_to_expected_type` catches spec errors in FM_* constants
+5. **Always Green** — all 196 tests pass at every commit (0 ignored)
 
 ---
 
 ## Flit Mode Implementation Status (v0.5.0)
 
-All tiers complete -- no `#[ignore]` tests remain:
+All tiers complete — no `#[ignore]` tests remain:
 
 1. ~~**Tier 1** — `FlitDW0` struct + `from_dw0()`~~ ✅ Done (v0.4.1)
-2. ~~**Tier 2** — `FlitTlpType` enum + `base_header_dw()` + `total_bytes()`~~ ✅ Done (v0.4.1)
+2. ~~**Tier 2** — `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` + `has_data_payload()`~~ ✅ Done (v0.5.0)
 3. ~~**Tier 3** — `FlitOhcA` + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`~~ ✅ Done (v0.4.1)
 4. ~~**Tier 4** — `FlitStreamWalker` iterator~~ ✅ Done (v0.5.0)
 5. ~~**Tier 5** — `TlpPacket::new_flit()` + `get_flit_type()`~~ ✅ Done (v0.5.0)

--- a/TESTS.md
+++ b/TESTS.md
@@ -2,124 +2,199 @@
 
 This document describes the test structure for the rtlp-lib crate.
 
+---
+
 ## Test Files
 
 ### 1. Unit Tests (`src/lib.rs`)
+
 **Purpose:** Test internal implementation details not exposed in the public API.
 
 **Location:** `#[cfg(test)] mod tests` inside `src/lib.rs`
 
-**Tests (6 total):**
-- `tlp_header_type` - Tests internal `TlpHeader` type detection
-- `tlp_header_works_all_zeros` - Tests bitfield parsing with zero values
-- `tlp_header_works_all_ones` - Tests bitfield parsing with all bits set
-- `test_invalid_format_error` - Tests error handling for invalid format values
-- `test_invalid_type_error` - Tests error handling for invalid type encoding
-- `test_unsupported_combination_error` - Tests error handling for unsupported format/type combinations
+**Test count: 48**
+
+Categories:
+- `TlpHeader` bitfield parsing (all-zeros, all-ones, bit-position verification)
+- TLP type decoding — every supported (fmt, type) pair
+- Unsupported / invalid combination error paths
+- DMWr (Deferrable Memory Write) header decode
+- Atomic operand parsing via `new_atomic_req()`
+- Completion lower-address field decode
+- Message DW3/DW4 upper-bit preservation
+- `TlpMode::Flit` stub — returns `NotImplemented`
+- `TlpError::NotImplemented` distinctness
+- `TlpMode` derive traits (Debug, Clone, Copy, PartialEq)
 
 **Why separate:** These tests use `TlpHeader` which is an internal implementation detail, not part of the public API.
 
-### 2. Integration Tests (`tests/tlp_tests.rs`)
-**Purpose:** Test the library's functional behavior through its public API.
+---
 
-**Tests (8 total):**
-- `test_tlp_packet` - Basic TLP packet parsing
-- `test_complreq_trait` - Completion request trait functionality
-- `test_configreq_trait` - Configuration request trait functionality
-- `is_memreq_tag_works` - Memory request tag extraction (3DW and 4DW)
-- `is_memreq_3dw_address_works` - 32-bit address parsing
-- `is_memreq_4dw_address_works` - 64-bit address parsing
-- `is_tlppacket_creates` - TlpPacketHeader creation
-- `test_tlp_packet_invalid_type` - Error propagation through TlpPacket API
+### 2. Non-Flit Integration Tests (`tests/non_flit_tests.rs`)
 
-**Why separate:** These verify end-to-end functionality that users will rely on.
+**Purpose:** Functional behavior of the library through the public API using `TlpMode::NonFlit` (PCIe 1.0–5.0).
+
+**Test count: 16**
+
+Tests:
+- `test_tlp_packet` — basic TLP packet parsing
+- `test_complreq_trait` — completion request trait fields
+- `test_configreq_trait` — configuration request trait fields
+- `is_memreq_tag_works` — tag extraction (3DW and 4DW)
+- `is_memreq_3dw_address_works` — 32-bit address parsing
+- `is_memreq_4dw_address_works` — 64-bit address parsing
+- `is_tlppacket_creates` — `TlpPacketHeader` construction
+- `test_tlp_packet_invalid_type` — error propagation
+- `atomic_fetchadd_3dw_32_parses_operands` — FetchAdd W32 operand
+- `atomic_swap_4dw_64_parses_operands` — Swap W64 operand
+- `atomic_cas_3dw_32_parses_operands` — CAS W32 two operands
+- `atomic_fetchadd_rejects_invalid_operand_length` — bad operand size
+- `dmwr32_decode_via_tlppacket` — DMWr 3DW decode
+- `dmwr64_decode_via_tlppacket` — DMWr 4DW decode
+- `dmwr_rejects_nodata_formats` — DMWr negative test
+- `dmwr_is_non_posted` — non-posted predicate
+
+**Why separate:** These verify end-to-end non-flit functionality that users rely on.  
+All calls pass `TlpMode::NonFlit` explicitly.
+
+---
 
 ### 3. API Contract Tests (`tests/api_tests.rs`)
-**Purpose:** Ensure the public API remains stable and catch breaking changes.
 
-**Tests (42 total), organized by category:**
+**Purpose:** Ensure the public API remains stable and catch breaking changes.  
+Mode-agnostic — tests API surface only, not behavior.
 
-#### Error Type Tests (3 tests)
-- Verify `TlpError` enum exists and is accessible
-- Check `Debug` and `PartialEq` trait implementations
-- Ensure all error variants are available
+**Test count: 55**
 
-#### TlpFmt Enum Tests (3 tests)
-- Verify all format variants exist
-- Test `try_from` conversions for valid values
-- Test `try_from` returns errors for invalid values
+Categories:
+- `TlpError` enum — all variants including `NotImplemented`, Debug, PartialEq
+- `TlpMode` enum — NonFlit and Flit variants, Copy/Clone/Debug/PartialEq
+- `TlpMode::Flit` stub — returns `NotImplemented` for Packet and Header
+- `TlpFmt` enum — all variants, `TryFrom<u32>` valid and invalid values
+- `TlpType` enum — all 21 variants, Debug, PartialEq
+- `TlpPacket` — constructor, getters, error conditions
+- `TlpPacketHeader` — constructor, `get_tlp_type()`
+- `MemRequest` trait — 3DW and 4DW struct accessibility and method types
+- `ConfigurationRequest` trait — struct and method types
+- `CompletionRequest` trait — struct and method types
+- `MessageRequest` trait — struct and method types
+- `AtomicOp` / `AtomicWidth` — enum variants, Debug, PartialEq
+- Factory functions — `new_mem_req`, `new_conf_req`, `new_cmpl_req`, `new_msg_req`, `new_atomic_req`
+- API stability compilation test — all public types and functions
+- Edge cases — minimum size, empty data, payload preservation
 
-#### TlpType Enum Tests (3 tests)
-- Verify all 20 TLP type variants exist
-- Check `Debug` and `PartialEq` implementations
+**Why separate:** These serve as a living contract specification. A failure indicates a breaking API change.
 
-#### TlpPacket Tests (10 tests)
-- Constructor existence
-- `get_tlp_type()` return type and error handling
-- `get_tlp_format()` existence
-- `get_data()` functionality
-- Validation of different packet types
-- Error conditions (invalid format, invalid type)
+---
 
-#### TlpPacketHeader Tests (2 tests)
-- Constructor existence
-- `get_tlp_type()` return type
+### 4. Flit Mode Tests (`tests/flit_mode_tests.rs`)
 
-#### Trait Tests (12 tests)
-- `MemRequest` trait methods and return types (3DW and 4DW)
-- `ConfigurationRequest` trait methods and return types
-- `CompletionRequest` trait methods and return types
-- `MessageRequest` trait methods and return types
-- Struct accessibility tests
+**Purpose:** Test plan and byte-vector constants for PCIe 6.x flit mode TLP parsing.
 
-#### Factory Function Tests (4 tests)
-- `new_mem_req()` signature and return type
-- `new_conf_req()` signature and return type
-- `new_cmpl_req()` signature and return type
-- `new_msg_req()` signature and return type
+**Test count: 30 total (5 passing, 25 `#[ignore]`)**
 
-#### API Stability Test (1 test)
-- Compilation test ensuring all public types remain available
-- Will fail to compile if any public API is removed or renamed
+#### Tier 0 — Current stubs ✅ (5 tests, all pass today)
 
-#### Edge Case Tests (3 tests)
-- Minimum packet size handling
-- Empty data section handling
-- Data payload preservation
+| Test | What it checks |
+|---|---|
+| `flit_packet_new_returns_not_implemented` | `TlpMode::Flit` → `NotImplemented` |
+| `flit_header_new_returns_not_implemented` | Same for `TlpPacketHeader` |
+| `flit_byte_vectors_have_correct_sizes` | 16 FM_* constants have correct byte lengths |
+| `flit_dw0_type_bytes_are_correct` | Byte 0 of each vector matches expected type code |
+| `flit_dw0_ohc_bytes_are_correct` | Byte 1 OHC field matches expected flags |
 
-**Why separate:** These tests serve as a living contract specification. If any test fails, it indicates a breaking API change that will affect users.
+#### Tier 1 — DW0 field extraction `#[ignore]` (6 tests)
+Unlock: `FlitDW0` struct + `flit_dw0_from_bytes()` in `src/lib.rs`
 
-### 4. Documentation Tests (5 tests)
-**Purpose:** Ensure examples in documentation compile and run correctly.
+#### Tier 2 — Per-vector header + size validation `#[ignore]` (11 tests)
+Unlock: `FlitTlpType` enum + type-to-header-size table in `src/lib.rs`
 
-**Location:** Embedded in doc comments throughout `src/lib.rs`
+#### Tier 3 — OHC field parsing and mandatory-OHC validation `#[ignore]` (6 tests)
+Unlock: OHC parser + `TlpError::MissingMandatoryOhc` variant
 
-**Tests:**
+#### Tier 4 — Packed stream walking `#[ignore]` (2 tests)
+Unlock: `FlitStreamWalker` iterator in `src/lib.rs`
+
+#### Tier 5 — End-to-end `TlpMode::Flit` pipeline `#[ignore]` (6 tests)
+Unlock: `TlpPacket::new_flit()` fully wired
+
+**FM_* byte vector constants (all defined in this file):**
+
+| Constant | Bytes | Description |
+|---|---|---|
+| `FM_NOP` | 4 | Flit NOP (type 0x00) |
+| `FM_MRD32_MIN` | 12 | MRd32, minimal, no OHC |
+| `FM_MRD32_A1_PASID` | 16 | MRd32 + OHC-A1 (PASID) |
+| `FM_MWR32_MIN` | 16 | MWr32, minimal, no OHC |
+| `FM_MWR32_PARTIAL_A1` | 20 | MWr32 + OHC-A1 (partial BE) |
+| `FM_IOWR_A2` | 20 | IOWr + mandatory OHC-A2 |
+| `FM_CFGWR0_A3` | 20 | CfgWr0 + mandatory OHC-A3 |
+| `FM_UIOMRD64_MIN` | 16 | UIOMRd 4DW header, no OHC |
+| `FM_UIOMWR64_MIN` | 24 | UIOMWr 4DW header + 2DW payload |
+| `FM_MSG_TO_RC` | 12 | Message routed to RC, no data |
+| `FM_MSGD_TO_RC` | 16 | Message with data routed to RC |
+| `FM_FETCHADD32` | 16 | FetchAdd 32-bit atomic |
+| `FM_CAS32` | 20 | CAS 32-bit atomic |
+| `FM_DMWR32` | 16 | DMWr 32-bit |
+| `FM_STREAM_FRAGMENT_0` | 48 | 4 back-to-back TLPs |
+| `FM_LOCAL_PREFIX_ONLY` | 4 | Local TLP Prefix token |
+
+For design rationale see `docs/flit_mode_test_plan.md`.
+
+---
+
+### 5. Documentation Tests
+
+**Purpose:** Ensure examples in doc comments compile and run correctly.
+
+**Test count: 6**
+
+Tests embedded in `src/lib.rs` doc comments:
 - `TlpPacket` usage example
 - `new_mem_req` usage example
-- `new_conf_req` usage example  
+- `new_conf_req` usage example
 - `new_cmpl_req` usage example
 - `new_msg_req` usage example
+- `new_atomic_req` usage example
+
+---
 
 ## Test Summary
 
-| Test Type | Location | Count | Purpose |
-|-----------|----------|-------|---------|
-| Unit Tests | `src/lib.rs` | 6 | Internal implementation |
-| Integration Tests | `tests/tlp_tests.rs` | 8 | Functional behavior |
-| API Contract Tests | `tests/api_tests.rs` | 42 | API stability |
-| Doc Tests | `src/lib.rs` | 5 | Documentation examples |
-| **Total** | | **61** | |
+| Test Type | Location | Passes | Ignored | Purpose |
+|---|---|---|---|---|
+| Unit Tests | `src/lib.rs` | 48 | 0 | Internal implementation |
+| Non-Flit Integration | `tests/non_flit_tests.rs` | 16 | 0 | PCIe 1–5 functional behavior |
+| API Contract | `tests/api_tests.rs` | 55 | 0 | Public API stability |
+| Flit Mode | `tests/flit_mode_tests.rs` | 5 | 25 | PCIe 6.x test plan |
+| Doc Tests | `src/lib.rs` | 6 | 0 | Documentation examples |
+| **Total** | | **130** | **25** | |
+
+> `#[ignore]` tests compile but do not run by default.  
+> Run `cargo test -- --ignored` to see all pending flit mode tests.
+
+---
 
 ## Running Tests
 
 ```bash
-# Run all tests
+# Run all tests (non-ignored)
 cargo test
 
-# Run specific test file
+# Run only non-flit integration tests
+cargo test --test non_flit_tests
+
+# Run only flit mode tests (Tier 0 only — rest ignored)
+cargo test --test flit_mode_tests
+
+# Run only flit mode Tier 0 stubs
+cargo test --test flit_mode_tests flit_packet
+
+# See all pending flit mode tests (will show as 'FAILED - panicked at todo!')
+cargo test --test flit_mode_tests -- --ignored
+
+# Run only API contract tests
 cargo test --test api_tests
-cargo test --test tlp_tests
 
 # Run unit tests only
 cargo test --lib
@@ -127,21 +202,31 @@ cargo test --lib
 # Run doc tests only
 cargo test --doc
 
-# Run with output
+# Run with output visible
 cargo test -- --nocapture
 ```
 
+---
+
 ## Benefits of This Structure
 
-1. **Breaking Change Detection:** API tests will fail if the public interface changes
-2. **Clear Separation:** Unit tests focus on internals, integration tests on behavior
-3. **Documentation:** Tests serve as usage examples for the API
-4. **Confidence:** Comprehensive coverage means safe refactoring
-5. **Gen6 Preparation:** Clean structure ready for adding Gen6-specific tests
+1. **Breaking Change Detection** — `api_tests.rs` fails if the public interface changes
+2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
+3. **Incremental Plan** — flit mode tiers unlock as implementation lands
+4. **Documentation** — `#[ignore]` test bodies describe exactly what to implement
+5. **Always Green** — all 130 non-ignored tests pass at every commit
 
-## Future Work
+---
 
-When adding Gen6 packet parsing support:
-- Add Gen6-specific tests to `tests/tlp_tests.rs`
-- Add Gen6 API contracts to `tests/api_tests.rs`
-- Update this document with new test counts
+## Future Work (Flit Mode Implementation)
+
+To remove `#[ignore]` from flit mode tests, implement in order:
+
+1. **Tier 1** — `FlitDW0` struct + `flit_dw0_from_bytes()`
+2. **Tier 2** — `FlitTlpType` enum + base header size table
+3. **Tier 3** — OHC parser + `TlpError::MissingMandatoryOhc`
+4. **Tier 4** — `FlitStreamWalker` iterator
+5. **Tier 5** — Wire `TlpMode::Flit` in `TlpPacket::new`
+6. Bump version to `0.5.0`
+
+See `docs/flit_mode_test_plan.md` for full architectural decisions and acceptance criteria.

--- a/TESTS.md
+++ b/TESTS.md
@@ -12,7 +12,7 @@ This document describes the test structure for the rtlp-lib crate.
 
 **Location:** `#[cfg(test)] mod tests` inside `src/lib.rs`
 
-**Test count: 52**
+**Test count: 56**
 
 Categories:
 - `TlpHeader` bitfield parsing (all-zeros, all-ones, bit-position verification)
@@ -27,6 +27,8 @@ Categories:
 - `TlpError::NotImplemented` distinctness
 - `TlpMode` derive traits (Debug, Clone, Copy, PartialEq)
 - `is_non_posted()` exhaustive coverage — all 21 `TlpType` variants
+- `packet_mode_returns_correct_mode` — `TlpPacket::mode()` returns `NonFlit`/`Flit` correctly
+- `tlp_packet_debug` / `tlp_packet_debug_flit` / `tlp_packet_header_debug` — `Debug` formatting for both packet types
 
 **Why separate:** These tests use `TlpHeader` which is an internal implementation detail, not part of the public API.
 
@@ -75,7 +77,7 @@ All calls pass `TlpMode::NonFlit` explicitly.
 **Purpose:** Ensure the public API remains stable and catch breaking changes.  
 Mode-agnostic — tests API surface only, not behavior.
 
-**Test count: 67**
+**Test count: 77**
 
 Categories:
 - `TlpError` enum — all variants including `NotImplemented`, `MissingMandatoryOhc`, Display, PartialEq, `std::error::Error`
@@ -83,17 +85,19 @@ Categories:
 - `TlpMode::Flit` — now implemented for `TlpPacket::new()`; `TlpPacketHeader::new()` still returns `NotImplemented`
 - `TlpFmt` enum — all variants, `TryFrom<u32>` valid and invalid values
 - `TlpType` enum — all 21 variants, Debug, PartialEq
-- `TlpPacket` — constructor, `get_tlp_type()`, `get_tlp_format()`, `data()` (new), `get_data()` (deprecated, backward-compat)
-- `TlpPacketHeader` — constructor, `get_tlp_type()`
+- `TlpPacket` — constructor, `tlp_type()`, `tlp_format()`, `data()`, `mode()`
+- `TlpPacketHeader` — constructor, `tlp_type()`
 - `MemRequest` trait — 3DW and 4DW struct accessibility and method types
 - `ConfigurationRequest` trait — struct and method types
 - `CompletionRequest` trait — struct and method types
 - `MessageRequest` trait — struct and method types
 - `AtomicOp` / `AtomicWidth` — enum variants, Debug, PartialEq
 - Factory functions — `new_mem_req`, `new_conf_req`, `new_cmpl_req`, `new_msg_req`, `new_atomic_req`
-- API stability compilation test — all public types and functions
+- API stability compilation test — all public types and functions (uses concrete `vec![]` calls for `impl Into<Vec<u8>>` factory fns)
+- **`mode()` tests** — `tlp_packet_mode_returns_correct_mode`, `tlp_packet_mode_consistent_with_flit_type`
+- **Backward compat tests** (`#[allow(deprecated)]`) — one test per deprecated `get_*` alias verifying it delegates correctly: `get_tlp_type`, `get_tlp_format`, `get_flit_type`, `get_header`, `get_data`
+- **Debug trait tests** — `tlp_packet_implements_debug`, `tlp_packet_implements_debug_flit`, `tlp_packet_header_implements_debug`
 - Edge cases — minimum size, empty data, payload preservation
-- `tlp_packet_data_method_exists` — verifies the new `data()` API
 
 **Why separate:** These serve as a living contract specification. A failure indicates a breaking API change.
 
@@ -129,7 +133,7 @@ Implemented: `FlitOhcA::from_bytes()` + `FlitDW0::validate_mandatory_ohc()` + `T
 Implemented: `FlitStreamWalker` iterator in `src/lib.rs`
 
 #### Tier 5 — End-to-end `TlpMode::Flit` pipeline ✅ (10 tests — implemented)
-Implemented: `TlpPacket::new_flit()` + `get_flit_type()`
+Implemented: `TlpPacket::new_flit()` + `flit_type()`
 
 Includes atomic operand-value verification for `FM_FETCHADD32` (operand=0x01000000) and `FM_CAS32` (compare=0x11111111, swap=0x22222222).
 
@@ -162,12 +166,14 @@ For design rationale see `docs/flit_mode_test_plan.md`.
 
 **Purpose:** Ensure examples in doc comments compile and run correctly.
 
-**Test count: 7**
+**Test count: 9**
 
 Tests embedded in `src/lib.rs` doc comments:
 - `TlpPacket` usage example
+- `TlpPacket::mode()` usage example (includes `_ => {}` wildcard for `#[non_exhaustive]`)
+- `TlpType::is_posted()` usage example
 - `new_mem_req` usage example
-- `new_conf_req` usage example (updated: 12-byte input, uses `data().to_vec()`)
+- `new_conf_req` usage example (uses `data()` directly — no `.to_vec()`)
 - `new_cmpl_req` usage example
 - `new_msg_req` usage example
 - `new_atomic_req` usage example
@@ -179,12 +185,12 @@ Tests embedded in `src/lib.rs` doc comments:
 
 | Test Type | Location | Passes | Ignored | Purpose |
 |---|---|---|---|---|
-| Unit Tests | `src/lib.rs` | 52 | 0 | Internal implementation |
+| Unit Tests | `src/lib.rs` | 56 | 0 | Internal implementation |
 | Non-Flit Integration | `tests/non_flit_tests.rs` | 25 | 0 | PCIe 1–5 functional behavior |
-| API Contract | `tests/api_tests.rs` | 67 | 0 | Public API stability |
+| API Contract | `tests/api_tests.rs` | 77 | 0 | Public API stability |
 | Flit Mode | `tests/flit_mode_tests.rs` | 45 | 0 | PCIe 6.x — all tiers implemented |
-| Doc Tests | `src/lib.rs` | 7 | 0 | Documentation examples |
-| **Total** | | **196** | **0** | |
+| Doc Tests | `src/lib.rs` | 9 | 0 | Documentation examples |
+| **Total** | | **212** | **0** | |
 
 > All flit mode tiers (0–5) are implemented. Zero `#[ignore]` tests remain.
 
@@ -223,7 +229,7 @@ cargo test -- --nocapture
 2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
 3. **Incremental Plan** — flit mode tiers document implementation history
 4. **Parser-Driven Vector Tests** — `flit_all_fm_vectors_parse_to_expected_type` catches spec errors in FM_* constants
-5. **Always Green** — all 196 tests pass at every commit (0 ignored)
+5. **Always Green** — all 212 tests pass at every commit (0 ignored)
 
 ---
 
@@ -235,6 +241,6 @@ All tiers complete — no `#[ignore]` tests remain:
 2. ~~**Tier 2** — `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` + `has_data_payload()`~~ ✅ Done (v0.5.0)
 3. ~~**Tier 3** — `FlitOhcA` + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`~~ ✅ Done (v0.4.1)
 4. ~~**Tier 4** — `FlitStreamWalker` iterator~~ ✅ Done (v0.5.0)
-5. ~~**Tier 5** — `TlpPacket::new_flit()` + `get_flit_type()`~~ ✅ Done (v0.5.0)
+5. ~~**Tier 5** — `TlpPacket::new_flit()` + `flit_type()`~~ ✅ Done (v0.5.0)
 
 See `docs/flit_mode_test_plan.md` for full architectural decisions and acceptance criteria.

--- a/TESTS.md
+++ b/TESTS.md
@@ -64,7 +64,7 @@ All calls pass `TlpMode::NonFlit` explicitly.
 **Purpose:** Ensure the public API remains stable and catch breaking changes.  
 Mode-agnostic — tests API surface only, not behavior.
 
-**Test count: 60**
+**Test count: 64**
 
 Categories:
 - `TlpError` enum — all variants including `NotImplemented`, Debug, PartialEq
@@ -91,7 +91,7 @@ Categories:
 
 **Purpose:** Test plan and byte-vector constants for PCIe 6.x flit mode TLP parsing.
 
-**Test count: 40 total (26 passing, 14 `#[ignore]`)**
+**Test count: 40 total (32 passing, 8 `#[ignore]`)**
 
 #### Tier 0 — Current stubs ✅ (5 tests — permanent regression guards)
 
@@ -109,8 +109,8 @@ Implemented: `FlitDW0::from_dw0()` in `src/lib.rs`
 #### Tier 2 — Per-vector header + size validation ✅ (13 tests — implemented)
 Implemented: `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` in `src/lib.rs`
 
-#### Tier 3 — OHC field parsing and mandatory-OHC validation `#[ignore]` (6 tests)
-Unlock: `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
+#### Tier 3 — OHC field parsing and mandatory-OHC validation ✅ (6 tests — implemented)
+Implemented: `FlitOhcA::from_bytes()` + `FlitDW0::validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
 
 #### Tier 4 — Packed stream walking `#[ignore]` (2 tests)
 Unlock: `FlitStreamWalker` iterator in `src/lib.rs`
@@ -165,13 +165,13 @@ Tests embedded in `src/lib.rs` doc comments:
 |---|---|---|---|---|
 | Unit Tests | `src/lib.rs` | 48 | 0 | Internal implementation |
 | Non-Flit Integration | `tests/non_flit_tests.rs` | 16 | 0 | PCIe 1–5 functional behavior |
-| API Contract | `tests/api_tests.rs` | 60 | 0 | Public API stability |
-| Flit Mode | `tests/flit_mode_tests.rs` | 26 | 14 | PCIe 6.x test plan |
+| API Contract | `tests/api_tests.rs` | 64 | 0 | Public API stability |
+| Flit Mode | `tests/flit_mode_tests.rs` | 32 | 8 | PCIe 6.x test plan |
 | Doc Tests | `src/lib.rs` | 6 | 0 | Documentation examples |
-| **Total** | | **156** | **14** | |
+| **Total** | | **166** | **8** | |
 
 > `#[ignore]` tests compile but do not run by default.  
-> Run `cargo test -- --ignored` to see all pending flit mode tests (Tier 3–5).
+> Run `cargo test -- --ignored` to see all pending flit mode tests (Tier 4–5).
 
 ---
 
@@ -214,7 +214,7 @@ cargo test -- --nocapture
 2. **Mode Separation** — non-flit and flit tests are in separate files with explicit scoping
 3. **Incremental Plan** — flit mode tiers unlock as implementation lands
 4. **Documentation** — `#[ignore]` test bodies describe exactly what to implement
-5. **Always Green** — all 156 non-ignored tests pass at every commit
+5. **Always Green** — all 166 non-ignored tests pass at every commit
 
 ---
 
@@ -224,7 +224,7 @@ To remove `#[ignore]` from flit mode tests, implement in order:
 
 1. ~~**Tier 1** — `FlitDW0` struct + `flit_dw0_from_bytes()`~~ ✅ Done (v0.4.1)
 2. ~~**Tier 2** — `FlitTlpType` enum + base header size table~~ ✅ Done (v0.4.1)
-3. **Tier 3** — `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`
+3. ~~**Tier 3** — `FlitOhcA` struct + `validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`~~ ✅ Done (v0.4.1)
 4. **Tier 4** — `FlitStreamWalker` iterator
 5. **Tier 5** — Wire `TlpMode::Flit` in `TlpPacket::new`
 6. Bump version to `0.5.0`

--- a/docs/api_guide.md
+++ b/docs/api_guide.md
@@ -1,0 +1,626 @@
+# rtlp-lib API Guide
+
+This guide walks through the library from a user perspective: how to parse
+TLPs, which method to call and when, how ownership and lifetimes work, and
+how to extend or test code that uses the library.
+
+---
+
+## Table of Contents
+
+1. [Core Concepts](#1-core-concepts)
+2. [Parsing a Non-Flit TLP (PCIe 1.0–5.0)](#2-parsing-a-non-flit-tlp-pcie-10-50)
+3. [Mode Dispatch — Handling Both Modes in the Same Code Path](#3-mode-dispatch--handling-both-modes-in-the-same-code-path)
+4. [Non-Flit TLP Types — per-type field extraction](#4-non-flit-tlp-types--per-type-field-extraction)
+5. [Parsing a Flit-Mode TLP (PCIe 6.x)](#5-parsing-a-flit-mode-tlp-pcie-6x)
+6. [Flit Stream Walking](#6-flit-stream-walking)
+7. [Ownership and Lifetimes](#7-ownership-and-lifetimes)
+8. [Error Handling](#8-error-handling)
+9. [Non-Posted vs Posted Transactions](#9-non-posted-vs-posted-transactions)
+10. [Deprecated API Migration](#10-deprecated-api-migration)
+11. [How the API Tests Work](#11-how-the-api-tests-work)
+
+---
+
+## 1. Core Concepts
+
+### `TlpPacket` — the single entry point
+
+Everything starts with `TlpPacket::new(bytes, mode)`:
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode};
+
+let bytes: Vec<u8> = capture_from_hardware(); // your byte source
+let pkt = TlpPacket::new(bytes, TlpMode::NonFlit)?;
+```
+
+`TlpPacket::new` does three things:
+1. Validates the length (must be ≥ 4 bytes).
+2. Splits the input: **DW0** (first 4 bytes) goes into the header; the rest
+   becomes the data payload accessible via `pkt.data()`.
+3. For flit mode, additionally parses the DW0 type code and validates
+   mandatory OHC fields.
+
+### The two-surface design
+
+The library has **two separate parsing surfaces** because flit-mode and
+non-flit-mode use completely different DW0 encodings:
+
+| Surface | Mode | DW0 encoding | Type method |
+|---------|------|--------------|-------------|
+| Non-flit | `TlpMode::NonFlit` | `Fmt[2:0] \| Type[4:0]` | `pkt.tlp_type()` → `TlpType` |
+| Flit | `TlpMode::Flit` | flat 8-bit type code | `pkt.flit_type()` → `Option<FlitTlpType>` |
+
+The `mode()` method tells you which surface to use:
+
+```rust
+match pkt.mode() {
+    TlpMode::NonFlit => { /* use tlp_type(), tlp_format(), header() */ }
+    TlpMode::Flit    => { /* use flit_type() */ }
+    _ => {}  // TlpMode is #[non_exhaustive]; wildcard required in external code
+}
+```
+
+> **Why `mode()` instead of `flit_type().is_some()`?**  
+> Both are equivalent, but `mode()` makes the dispatch intent explicit and
+> reads like documentation. Compare with `pnet`'s pattern of separate
+> packet types per protocol layer — we encode the same clarity in a single
+> `match` expression.
+
+---
+
+## 2. Parsing a Non-Flit TLP (PCIe 1.0–5.0)
+
+### Step 1 — create the packet
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, TlpError};
+
+let bytes = vec![
+    0x40, 0x00, 0x00, 0x01,   // DW0: MemWrite 3DW, TC=0, length=1
+    0x00, 0x01, 0x20, 0x0F,   // DW1: req_id=0x0001 tag=0x20 BE=0x0F
+    0xDE, 0xAD, 0xBE, 0xEF,   // DW2: address32 = 0xDEADBEEF
+    0xCA, 0xFE, 0xBA, 0xBE,   // payload DW
+];
+
+let pkt = TlpPacket::new(bytes, TlpMode::NonFlit)?;
+```
+
+### Step 2 — decode the type
+
+```rust
+let tlp_type   = pkt.tlp_type()?;    // → TlpType::MemWriteReq
+let tlp_format = pkt.tlp_format()?;  // → TlpFmt::WithDataHeader3DW
+```
+
+`tlp_type()` decodes both the `Fmt` and `Type` fields together so you never
+see an impossible combination — an `IORead` with a 4DW header is a
+`TlpError::UnsupportedCombination`, not a valid `TlpType`.
+
+### Step 3 — extract per-type fields
+
+Use the appropriate factory function, passing `pkt.data()` directly:
+
+```rust
+use rtlp_lib::new_mem_req;
+
+// data() returns &[u8] — no allocation
+let mr = new_mem_req(pkt.data(), &tlp_format)?;
+println!("Address: 0x{:08X}", mr.address());
+println!("Req ID:  0x{:04X}", mr.req_id());
+println!("Tag:     0x{:02X}", mr.tag());
+```
+
+> **Ownership note:** `pkt.data()` returns `&[u8]` borrowed from `pkt`.  
+> The factory functions accept `impl Into<Vec<u8>>`, so `&[u8]` is coerced
+> into an owned `Vec<u8>` internally — a single allocation at the point you
+> need the fields, not at parse time.
+
+---
+
+## 3. Mode Dispatch — Handling Both Modes in the Same Code Path
+
+If your code receives packets of unknown framing (e.g., a mixed PCIe 5/6
+trace), use `mode()` to branch cleanly:
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, TlpType, FlitTlpType};
+
+fn process(pkt: &TlpPacket) {
+    match pkt.mode() {
+        TlpMode::NonFlit => process_non_flit(pkt),
+        TlpMode::Flit    => process_flit(pkt),
+        _ => eprintln!("unknown mode"),
+    }
+}
+
+fn process_non_flit(pkt: &TlpPacket) {
+    match pkt.tlp_type().unwrap() {
+        TlpType::MemReadReq  => println!("memory read"),
+        TlpType::MemWriteReq => println!("memory write @ {} bytes", pkt.data().len()),
+        other                => println!("non-flit TLP: {:?}", other),
+    }
+}
+
+fn process_flit(pkt: &TlpPacket) {
+    match pkt.flit_type() {
+        Some(FlitTlpType::MemRead32)  => println!("flit MRd32"),
+        Some(FlitTlpType::MemWrite32) => println!("flit MWr32 @ {} bytes", pkt.data().len()),
+        Some(other)                   => println!("flit TLP: {:?}", other),
+        None                          => unreachable!("mode() returned Flit"),
+    }
+}
+```
+
+---
+
+## 4. Non-Flit TLP Types — per-type field extraction
+
+### Memory Requests (MemRead, MemWrite, MemReadLock, DMWr, IORead, IOWrite)
+
+All share the `MemRequest` trait. Use `new_mem_req(bytes, &fmt)`.
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, TlpType, TlpFmt, new_mem_req};
+
+let pkt = TlpPacket::new(bytes, TlpMode::NonFlit)?;
+let fmt = pkt.tlp_format()?;
+
+// Covers MemRead/Write 32 and 64-bit, IORead/Write, DMWr
+let mr = new_mem_req(pkt.data(), &fmt)?;
+println!("address={:#x} req_id={:#06x} tag={:#04x}",
+         mr.address(), mr.req_id(), mr.tag());
+
+// For 3DW headers, address() returns a 32-bit value zero-extended to u64
+// For 4DW headers, address() returns the full 64-bit value
+```
+
+`new_mem_req` selects `MemRequest3DW` or `MemRequest4DW` based on `fmt`, then
+returns a `Box<dyn MemRequest>` so callers never need to match on 3DW vs 4DW.
+
+### Configuration Requests
+
+Configuration requests are always 3DW. `new_conf_req` only needs the bytes.
+
+```rust
+use rtlp_lib::new_conf_req;
+
+// data() contains DW1+DW2 (8 bytes)
+let cr = new_conf_req(pkt.data());
+println!("bus={} dev={} func={} reg={}",
+         cr.bus_nr(), cr.dev_nr(), cr.func_nr(), cr.reg_nr());
+```
+
+### Completions
+
+```rust
+use rtlp_lib::new_cmpl_req;
+
+let cpl = new_cmpl_req(pkt.data());
+println!("status={} byte_count={} lower_addr=0x{:02x}",
+         cpl.cmpl_stat(), cpl.byte_cnt(), cpl.laddr());
+```
+
+> **Note on `laddr()`:** The 7-bit Lower Address field (bits `[6:0]`) is
+> preserved in full — bit 6 had previously been incorrectly masked.
+
+### Message Requests
+
+```rust
+use rtlp_lib::new_msg_req;
+
+let msg = new_msg_req(pkt.data());
+println!("msg_code=0x{:02X} dw3=0x{:08X} dw4=0x{:08X}",
+         msg.msg_code(), msg.dw3(), msg.dw4());
+```
+
+`dw3()` and `dw4()` return the full 32-bit DW values — all 32 bits preserved.
+
+### Atomic Operations
+
+Atomics are the only type parsed through the full packet rather than just
+the data, because the operand width and layout depend on the format field
+(3DW → 32-bit operands, 4DW → 64-bit).
+
+```rust
+use rtlp_lib::new_atomic_req;
+
+let ar = new_atomic_req(&pkt)?;
+println!("op={:?} width={:?} operand0=0x{:X}",
+         ar.op(), ar.width(), ar.operand0());
+
+// CAS: operand0 = compare value, operand1 = swap value
+if let Some(swap) = ar.operand1() {
+    println!("swap value=0x{:X}", swap);
+}
+```
+
+`new_atomic_req` validates that the data length exactly matches
+`header_size + operand_count × operand_size` and returns
+`Err(TlpError::InvalidLength)` if not.
+
+---
+
+## 5. Parsing a Flit-Mode TLP (PCIe 6.x)
+
+### Single-packet parsing
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, FlitTlpType};
+
+// MWr32 flit: DW0(type=0x40, length=1) + 2 header DWs + 1 payload DW
+let bytes = vec![
+    0x40, 0x00, 0x00, 0x01,  // DW0: MemWrite32, TC=0, ohc=0, length=1
+    0x00, 0x00, 0x00, 0x00,  // DW1
+    0x00, 0x00, 0x10, 0x00,  // DW2: address32 = 0x1000
+    0xDE, 0xAD, 0xBE, 0xEF,  // payload
+];
+
+let pkt = TlpPacket::new(bytes, TlpMode::Flit)?;
+
+assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemWrite32));
+// data() returns payload bytes (after base header + OHC words)
+assert_eq!(pkt.data(), [0xDE, 0xAD, 0xBE, 0xEF]);
+```
+
+### Read requests have no payload
+
+In flit mode, a read request never carries a payload even when `Length > 0`
+(the Length field describes the expected completion, not the request):
+
+```rust
+let mrd32_bytes = vec![
+    0x03, 0x00, 0x00, 0x01,  // type=MemRead32, length=1 DW (completion size hint)
+    0x00, 0x00, 0x00, 0x00,  // DW1
+    0x00, 0x00, 0x10, 0x00,  // DW2: address32
+];
+let pkt = TlpPacket::new(mrd32_bytes, TlpMode::Flit)?;
+assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemRead32));
+assert!(pkt.data().is_empty());  // no payload in a read request
+```
+
+### OHC (Optional Header Content) words
+
+`FlitDW0` carries the OHC bitmap and count:
+
+```rust
+use rtlp_lib::FlitDW0;
+
+let dw0 = FlitDW0::from_dw0(&bytes)?;
+println!("ohc_count={} total_bytes={}", dw0.ohc_count(), dw0.total_bytes());
+```
+
+To parse an OHC-A word (carries PASID and byte-enables):
+
+```rust
+use rtlp_lib::FlitOhcA;
+
+// OHC-A starts at byte offset: base_header_dw() * 4
+let ohc_offset = dw0.tlp_type.base_header_dw() as usize * 4;
+let ohc = FlitOhcA::from_bytes(&raw_tlp_bytes[ohc_offset..])?;
+println!("PASID=0x{:05X} fdwbe=0x{:X} ldwbe=0x{:X}",
+         ohc.pasid, ohc.fdwbe, ohc.ldwbe);
+```
+
+### Mandatory OHC validation
+
+I/O Write and Config Type 0 Write require OHC-A. `TlpPacket::new` with
+`TlpMode::Flit` automatically validates this:
+
+```rust
+// I/O Write without OHC → error
+let bad_iowr = vec![0x42, 0x00, 0x00, 0x01, /* ... */];
+let result = TlpPacket::new(bad_iowr, TlpMode::Flit);
+assert_eq!(result.err(), Some(TlpError::MissingMandatoryOhc));
+```
+
+---
+
+## 6. Flit Stream Walking
+
+`FlitStreamWalker` iterates over a packed sequence of back-to-back flit
+TLPs in a byte buffer. It yields `Ok((offset, FlitTlpType, total_bytes))`
+for each TLP, or `Err(TlpError::InvalidLength)` if a TLP extends past the
+end of the buffer.
+
+```rust
+use rtlp_lib::{FlitStreamWalker, FlitTlpType, TlpError};
+
+let packed_tlps: &[u8] = &[
+    // NOP (4 bytes)
+    0x00, 0x00, 0x00, 0x00,
+    // MRd32 minimal (12 bytes)
+    0x03, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x10, 0x00,
+];
+
+for result in FlitStreamWalker::new(packed_tlps) {
+    match result {
+        Ok((offset, typ, size)) =>
+            println!("[{:3}] {:?} ({} bytes)", offset, typ, size),
+        Err(TlpError::InvalidLength) =>
+            eprintln!("truncated TLP — stream is corrupt"),
+        Err(e) =>
+            eprintln!("parse error: {}", e),
+    }
+}
+// Output:
+//   [  0] Nop (4 bytes)
+//   [  4] MemRead32 (12 bytes)
+```
+
+After the first error, the iterator returns `None` for all subsequent calls.
+
+---
+
+## 7. Ownership and Lifetimes
+
+### `data()` borrows from the packet
+
+```rust
+let pkt = TlpPacket::new(bytes, TlpMode::NonFlit)?;
+let payload: &[u8] = pkt.data();  // lifetime tied to `pkt`
+
+// This is fine — payload is used while pkt is alive:
+let mr = new_mem_req(payload, &pkt.tlp_format()?)?;
+
+// This would NOT compile — pkt moved/dropped before payload used:
+// drop(pkt);
+// println!("{:?}", payload);  // ← borrow-after-move error
+```
+
+### Factory functions own their bytes
+
+All factory functions (`new_mem_req`, `new_conf_req`, `new_cmpl_req`,
+`new_msg_req`) take `impl Into<Vec<u8>>` and store an owned `Vec<u8>`
+internally. The trait object they return owns its data:
+
+```rust
+// Passing pkt.data() (&[u8]) → one Vec allocation inside new_conf_req
+let cr: Box<dyn ConfigurationRequest> = new_conf_req(pkt.data());
+// `cr` is independent of `pkt` — pkt can be dropped here
+drop(pkt);
+println!("bus={}", cr.bus_nr());  // cr still valid
+```
+
+If you already have a `Vec<u8>`, you can pass it without cloning:
+```rust
+let owned: Vec<u8> = read_config_bytes();
+let cr = new_conf_req(owned);  // Vec moved in, no extra allocation
+```
+
+### `new_atomic_req` takes `&TlpPacket`
+
+The atomic parser borrows the packet for the duration of parsing and
+returns an owned `Box<dyn AtomicRequest>`:
+
+```rust
+let ar: Box<dyn AtomicRequest> = new_atomic_req(&pkt)?;
+// pkt still owned by you; ar is independent
+println!("{:?}", ar);
+```
+
+---
+
+## 8. Error Handling
+
+Every parsing step that can fail returns `Result<_, TlpError>`.
+`TlpError` implements `std::error::Error` and `Display`, so it composes
+naturally with `?` and `Box<dyn Error>`:
+
+```rust
+use rtlp_lib::{TlpPacket, TlpMode, TlpError};
+
+fn parse_tlp(bytes: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit)?;
+    let t   = pkt.tlp_type()?;
+    println!("TLP type: {}", t);  // TlpType implements Display
+    Ok(())
+}
+```
+
+### Error variants
+
+| Variant | When you see it |
+|---------|----------------|
+| `InvalidFormat` | Fmt bits are one of the three reserved values (0b101, 0b110, 0b111) |
+| `InvalidType` | Type bits don't match any known encoding |
+| `UnsupportedCombination` | Valid Fmt + Type individually, but not a legal pair (e.g. IO Request with 4DW header) |
+| `InvalidLength` | Byte slice < 4, or atomic payload size doesn't match expected |
+| `NotImplemented` | `TlpPacketHeader::new(TlpMode::Flit)`, or calling `tlp_type()` on a flit packet |
+| `MissingMandatoryOhc` | Flit IOWrite or CfgWrite0 without the required OHC-A word |
+
+### Pattern matching on errors
+
+```rust
+match pkt.tlp_type() {
+    Ok(t) => process(t),
+    Err(TlpError::UnsupportedCombination) => {
+        eprintln!("vendor-specific or reserved TLP, skipping");
+    }
+    Err(TlpError::InvalidFormat) => {
+        eprintln!("malformed DW0 — likely capture artifact");
+    }
+    Err(e) => return Err(e.into()),
+}
+```
+
+---
+
+## 9. Non-Posted vs Posted Transactions
+
+`TlpType::is_non_posted()` returns `true` for TLP types that require a
+completion. Use this for flow-control accounting, timeout logic, or
+filtering trace data:
+
+```rust
+use rtlp_lib::TlpType;
+
+fn requires_completion(t: &TlpType) -> bool {
+    t.is_non_posted()
+}
+
+// Non-posted (require completion): reads, I/O, config, atomics, DMWr
+assert!( TlpType::MemReadReq.is_non_posted());
+assert!( TlpType::IOWriteReq.is_non_posted());
+assert!( TlpType::ConfType0WriteReq.is_non_posted());
+assert!( TlpType::FetchAddAtomicOpReq.is_non_posted());
+assert!( TlpType::DeferrableMemWriteReq.is_non_posted());
+
+// Posted (no completion): memory writes, messages
+assert!(!TlpType::MemWriteReq.is_non_posted());
+assert!(!TlpType::MsgReq.is_non_posted());
+
+// Completions and prefixes are neither requests nor posted writes
+assert!(!TlpType::CplData.is_non_posted());
+assert!(!TlpType::LocalTlpPrefix.is_non_posted());
+```
+
+`is_posted()` is the convenience inverse: `!is_non_posted()`.
+
+---
+
+## 10. Deprecated API Migration
+
+In 0.5.0, all `get_*` methods were renamed to follow Rust naming conventions.
+The old names are still present with `#[deprecated]` markers so existing code
+continues to compile with a `cargo` warning.
+
+### Migration table
+
+| Deprecated method | Replacement | Notes |
+|---|---|---|
+| `pkt.get_tlp_type()` | `pkt.tlp_type()` | Same return type: `Result<TlpType, TlpError>` |
+| `pkt.get_tlp_format()` | `pkt.tlp_format()` | Same return type: `Result<TlpFmt, TlpError>` |
+| `pkt.get_flit_type()` | `pkt.flit_type()` | Same return type: `Option<FlitTlpType>` |
+| `pkt.get_header()` | `pkt.header()` | Same return type: `&TlpPacketHeader` |
+| `pkt.get_data()` | `pkt.data()` | **Different type:** `get_data()` → `Vec<u8>` (allocates); `data()` → `&[u8]` (zero-copy) |
+| `hdr.get_tlp_type()` | `hdr.tlp_type()` | Same return type |
+
+### Suppressing the warning during migration
+
+If you have a large codebase you can't migrate all at once:
+
+```rust
+#[allow(deprecated)]
+fn legacy_process(pkt: &TlpPacket) -> TlpType {
+    pkt.get_tlp_type().unwrap()  // suppress warning for this block only
+}
+```
+
+### What happens to `get_data()` users
+
+`get_data()` returns an owned `Vec<u8>` (clones the payload). The new
+`data()` returns `&[u8]` without allocating. Most call sites only read the
+data, so the migration is:
+
+```rust
+// Before:
+let bytes: Vec<u8> = pkt.get_data();
+let mr = new_mem_req(bytes, &fmt)?;
+
+// After (zero additional allocation):
+let mr = new_mem_req(pkt.data(), &fmt)?;
+```
+
+---
+
+## 11. How the API Tests Work
+
+`tests/api_tests.rs` serves three purposes simultaneously:
+
+### Purpose 1: Compilation = correctness
+
+Many tests contain no runtime assertions — they simply use every public
+type and function:
+
+```rust
+fn api_all_expected_public_types_are_available() {
+    use rtlp_lib::{TlpPacket, TlpMode, TlpType, /* ... */};
+    let _: Option<TlpPacket> = None;
+    // ...
+}
+```
+
+If `TlpPacket` is renamed or removed, this test fails to **compile**, giving
+an instant breaking-change signal before a single test runs.
+
+### Purpose 2: Behavioural contract
+
+Tests like `tlp_packet_mode_returns_correct_mode` assert specific return
+values. If the implementation changes the semantics (e.g. `mode()` returns
+the wrong variant), the test fails at runtime.
+
+### Purpose 3: Backward-compatibility enforcement
+
+The `#[allow(deprecated)]` tests prove that every deprecated alias still
+compiles and delegates to the new method:
+
+```rust
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_tlp_type_on_packet_delegates_to_tlp_type() {
+    let pkt = TlpPacket::new(/* ... */, TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type(), pkt.tlp_type());  // must match
+}
+```
+
+This ensures that code written against the old API continues to produce
+correct results even after the internal implementation moves to the new name.
+
+### Writing tests for your own code
+
+If you write code that processes `TlpPacket`s, mirror the same three-layer
+pattern:
+
+```rust
+// Layer 1: compilation test — your function accepts the right types
+fn my_decoder_accepts_tlp_packet(_pkt: &TlpPacket) {}
+
+// Layer 2: behaviour test — correct output for known input
+#[test]
+fn my_decoder_handles_mem_write() {
+    let bytes = vec![0x40, 0x00, 0x00, 0x01, /* ... */];
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::MemWriteReq);
+    // test your own logic here
+}
+
+// Layer 3: error path — your code handles bad input gracefully
+#[test]
+fn my_decoder_rejects_flit_packet() {
+    let pkt = TlpPacket::new(vec![0x00; 4], TlpMode::Flit).unwrap();
+    // tlp_type() returns Err(NotImplemented) for flit packets
+    assert!(pkt.tlp_type().is_err());
+}
+```
+
+---
+
+## Summary: the typical parsing flow
+
+```
+Vec<u8>  ──►  TlpPacket::new(bytes, mode)
+                    │
+                    ▼
+              pkt.mode()
+             /          \
+        NonFlit          Flit
+            │               │
+    pkt.tlp_type()   pkt.flit_type()
+    pkt.tlp_format()        │
+            │         FlitTlpType
+        TlpType               \── pkt.data() for payload bytes
+            │
+     match on TlpType
+     ├── Mem*    → new_mem_req(pkt.data(), &fmt)  → MemRequest trait
+     ├── Conf*   → new_conf_req(pkt.data())        → ConfigurationRequest trait
+     ├── Cpl*    → new_cmpl_req(pkt.data())        → CompletionRequest trait
+     ├── Msg*    → new_msg_req(pkt.data())          → MessageRequest trait
+     └── Atomic* → new_atomic_req(&pkt)            → AtomicRequest trait
+```
+
+All factory functions take `impl Into<Vec<u8>>` — pass `pkt.data()` directly,
+no `.to_vec()` needed.

--- a/docs/flit_mode_test_plan.md
+++ b/docs/flit_mode_test_plan.md
@@ -1,0 +1,299 @@
+# Flit Mode Test Plan
+
+**Status:** Planning — implementation pending  
+**Target release:** 0.5.0  
+**Reference:** `docs/flit_mode_tlp_examples.md`
+
+---
+
+## 1. Background
+
+PCIe 6.0 introduced **Flit Mode**, where TLPs are carried inside fixed 256-byte FLIT containers.
+The TLP structure inside a flit is fundamentally different from non-flit TLPs:
+
+### DW0 format comparison
+
+| Byte | Non-Flit (PCIe 1–5) | Flit Mode (PCIe 6.x) |
+|---|---|---|
+| 0 | `Fmt[2:0] \| Type[4:0]` | **`Type[7:0]`** — full flat 8-bit type code |
+| 1 | `T9, TC[2:0], T8, Attr_b2, LN, TH` | **`TC[2:0] \| OHC[4:0]`** — OHC presence flags |
+| 2 | `TD, EP, Attr[1:0], AT[1:0], Length[9:8]` | `TS[2:0] \| Attr[2:0] \| Length[9:8]` |
+| 3 | `Length[7:0]` | `Length[7:0]` |
+
+**Consequence:** The existing `TlpHeader` bitfield and `get_tlp_type()` logic is **completely
+incompatible with flit mode DW0**. Flit mode requires its own dedicated parser.
+
+### OHC — Optional Header Content
+
+OHC is a new flit-mode concept with no non-flit equivalent:
+
+- **`OHC[4:0]`** in DW0 byte 1 — each bit indicates an extra OHC word present in the header
+- Each OHC word adds **1 DW** to the header after the base header
+- Some TLP types have **mandatory OHC rules**:
+  - I/O Requests: OHC-A2 is mandatory
+  - Configuration Requests: OHC-A3 is mandatory
+  - Violation of mandatory OHC rules is a parser error
+
+### New TLP types
+
+Flit mode introduces types not present in the non-flit `TlpType` enum:
+
+| Type code | Name | Non-flit equivalent |
+|---|---|---|
+| `0x00` | NOP | — (new) |
+| `0x03` | MRd32 | MemReadReq (different encoding) |
+| `0x22` | UIOMRd (4DW) | — (new, PCIe 6.1+ UIO) |
+| `0x40` | MWr32 | MemWriteReq (different encoding) |
+| `0x42` | IOWr | IOWriteReq (different encoding) |
+| `0x44` | CfgWr0 | ConfType0WriteReq (different encoding) |
+| `0x4C` | FetchAdd32 | FetchAddAtomicOpReq (different encoding) |
+| `0x4E` | CAS32 | CompareSwapAtomicOpReq (different encoding) |
+| `0x5B` | DMWr32 | DeferrableMemWriteReq (different encoding) |
+| `0x61` | UIOMWr (4DW) | — (new, PCIe 6.1+ UIO) |
+| `0x70` | MsgD to RC | MsgReqData (different encoding) |
+| `0x8D` | Local TLP Prefix | LocalTlpPrefix (different encoding) |
+
+---
+
+## 2. Architectural Decisions
+
+### Decision 1: Separate `FlitTlpType` enum
+
+**Decision:** Introduce a new `FlitTlpType` enum, do **not** extend `TlpType`.
+
+**Rationale:**
+- Type code numbers are completely disjoint (flit MRd32=0x03 vs non-flit MRd=computed from fmt+type bits)
+- New types (NOP, UIOMRd, UIOMWr) have no non-flit equivalent
+- Mixing them into `TlpType` would create confusion and invalid `match` arms for callers on both paths
+
+```rust
+// Future addition to src/lib.rs
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FlitTlpType {
+    Nop,
+    MemRead32, MemRead64,
+    MemWrite32, MemWrite64,
+    IoRead, IoWrite,
+    CfgRead0, CfgWrite0, CfgRead1, CfgWrite1,
+    MsgToRc, MsgDToRc,      // ... other routing variants
+    Completion, CompletionWithData,
+    FetchAdd32, FetchAdd64,
+    Swap32, Swap64,
+    CompareSwap32, CompareSwap64,
+    DeferrableMemWrite32, DeferrableMemWrite64,
+    UioMemRead, UioMemWrite,   // PCIe 6.1+ UIO
+    LocalTlpPrefix,
+    // #[non_exhaustive] — future codes will be added without breaking match arms
+}
+```
+
+### Decision 2: New `FlitDW0` struct
+
+**Decision:** Introduce a `FlitDW0` struct to decode flit-mode DW0.
+
+```rust
+// Future addition to src/lib.rs
+pub struct FlitDW0 {
+    pub tlp_type: FlitTlpType,
+    pub tc: u8,
+    pub ohc: u8,           // 5-bit OHC presence bitmap
+    pub ts: u8,
+    pub attr: u8,
+    pub length: u16,       // in DW, 0 = 1024 DW
+}
+```
+
+### Decision 3: `TlpMode::Flit` wires to new parser
+
+**Decision:** When `TlpPacket::new(bytes, TlpMode::Flit)` is called, dispatch to
+`new_flit(bytes)` which uses `FlitDW0` instead of `TlpHeader`.
+
+Currently returns `Err(TlpError::NotImplemented)` — this is the stub that all
+Tier 5 tests verify will eventually succeed.
+
+### Decision 4: `#[ignore]` convention for unimplemented tiers
+
+**Decision:** Write full test bodies now, mark them `#[ignore]` until the required
+implementation exists. This gives us:
+- Compile-time confidence the test logic is correct
+- A runnable "progress check": `cargo test -- --ignored` shows what's pending
+- No blocked PRs — all tests pass (48+55+16+N_ignored+6 = green)
+
+---
+
+## 3. Test File Structure
+
+```
+tests/
+├── api_tests.rs          ← unchanged scope: public API surface stability
+│                            includes TlpMode enum tests, TlpError variants
+├── non_flit_tests.rs     ← renamed from tlp_tests.rs
+│                            all existing functional tests
+│                            explicit TlpMode::NonFlit at every call site
+└── flit_mode_tests.rs    ← new: flit parser test plan
+                             all FM_* byte vector constants defined here
+                             tiered test structure (Tier 0–5)
+```
+
+---
+
+## 4. Tier Definitions
+
+### Tier 0 — Current stubs ✅ (passes today)
+
+Tests that verify the current `NotImplemented` stub behavior.
+These are written and passing NOW.
+
+```rust
+// TlpPacket::new(bytes, TlpMode::Flit).err().unwrap() == TlpError::NotImplemented
+// TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap() == TlpError::NotImplemented
+```
+
+**Unlock condition:** N/A — these are permanent regression guards for the stub.
+
+---
+
+### Tier 1 — Flit DW0 field extraction `#[ignore]`
+
+Tests that decode individual fields from flit DW0 bytes.  
+Do NOT call `TlpPacket::new` — test a standalone `FlitDW0::from_dw0(bytes)` function.
+
+**Test inputs:** All 15 FM_* vectors (check byte 0, 1, 2, 3 independently).
+
+**Unlock condition:** `FlitDW0` struct and `FlitDW0::from_dw0()` added to `src/lib.rs`.
+
+---
+
+### Tier 2 — Per-vector header + size validation `#[ignore]`
+
+Tests that each FM_* vector produces the correct:
+- `FlitTlpType`
+- base header size in bytes
+- OHC count (number of extra DW words)
+- total header size = (base + OHC) × 4 bytes
+- payload length in bytes
+- total TLP size in bytes
+
+**Unlock condition:** `FlitTlpType` enum and type-to-header-size table in `src/lib.rs`.
+
+---
+
+### Tier 3 — OHC field parsing `#[ignore]`
+
+Tests that OHC words are parsed correctly:
+
+- `FM_MRD32_A1_PASID` → OHC-A1 present, PASID=0x12345, fdwbe=0xF, ldwbe=0x0
+- `FM_MWR32_PARTIAL_A1` → OHC-A1 present, fdwbe=0x3
+- `FM_IOWR_A2` → mandatory OHC-A2 present, fdwbe=0xF
+- `FM_CFGWR0_A3` → mandatory OHC-A3 present
+
+**Negative tests** (mandatory OHC validation):
+- `FM_IOWR_A2` with byte1=0x00 → `Err(TlpError::MissingMandatoryOhc)` (new error variant needed)
+- `FM_CFGWR0_A3` with byte1=0x00 → same error
+
+**Unlock condition:** OHC parser + `TlpError::MissingMandatoryOhc` variant.
+
+---
+
+### Tier 4 — Packed stream walking `#[ignore]`
+
+Tests that the parser can walk `FM_STREAM_FRAGMENT_0` (48 bytes containing 4 back-to-back TLPs)
+and correctly determine start offset, type, and size of each TLP.
+
+| Offset | Expected type | Expected size |
+|---|---|---|
+| 0 | NOP | 4 bytes |
+| 4 | MRd32 | 12 bytes |
+| 16 | MWr32 | 16 bytes |
+| 32 | UIOMRd | 16 bytes |
+| 48 | (end) | — |
+
+**Unlock condition:** `FlitStreamWalker` or iterator type over packed byte slice.
+
+---
+
+### Tier 5 — End-to-end `TlpMode::Flit` pipeline `#[ignore]`
+
+Tests that `TlpPacket::new(bytes, TlpMode::Flit)` succeeds for each FM_* vector
+and populates fields correctly.
+
+**Unlock condition:** `new_flit()` fully wired up inside `TlpPacket::new` dispatch.
+
+---
+
+## 5. Implementation Roadmap
+
+To unlock each tier, these additions to `src/lib.rs` are required:
+
+| Tier | What to add | New public API |
+|---|---|---|
+| 1 | `FlitDW0` struct + `from_dw0()` | `pub struct FlitDW0`, `pub fn flit_dw0_from_bytes()` |
+| 2 | `FlitTlpType` enum + size table | `pub enum FlitTlpType` |
+| 3 | OHC parser + `MissingMandatoryOhc` | `pub struct FlitOhc`, `TlpError::MissingMandatoryOhc` |
+| 4 | Stream walker | `pub struct FlitStreamWalker` or iterator |
+| 5 | `TlpPacket::new_flit()` | wires `TlpMode::Flit` to new parser |
+
+Each tier builds on the previous — merge order matters.
+
+---
+
+## 6. "Not Frozen Yet" — Do Not Write Tests For
+
+Per `flit_mode_tlp_examples.md` Appendix, the following should NOT be used
+as golden vectors until the full PCIe Base Spec is consulted:
+
+- `Cpl`, `CplD`, `UIORdCplD` — completion field packing not validated
+- Vectors using `OHC-A5`, `OHC-B`, `OHC-C`
+- IDE trailer examples
+- Non-zero 10-bit / 14-bit Tag packing
+
+---
+
+## 7. Test Vector Reference (from `flit_mode_tlp_examples.md`)
+
+All 15 constants are defined in `tests/flit_mode_tests.rs`:
+
+```
+FM_NOP                  [4 bytes]   Tier 1-5
+FM_MRD32_MIN            [12 bytes]  Tier 1-5
+FM_MRD32_A1_PASID       [16 bytes]  Tier 1-5 + OHC-A1 Tier 3
+FM_MWR32_MIN            [16 bytes]  Tier 1-5
+FM_MWR32_PARTIAL_A1     [20 bytes]  Tier 1-5 + OHC-A1 Tier 3
+FM_IOWR_A2              [20 bytes]  Tier 1-5 + OHC-A2 mandatory Tier 3
+FM_CFGWR0_A3            [20 bytes]  Tier 1-5 + OHC-A3 mandatory Tier 3
+FM_UIOMRD64_MIN         [16 bytes]  Tier 1-5
+FM_UIOMWR64_MIN         [24 bytes]  Tier 1-5
+FM_MSG_TO_RC            [12 bytes]  Tier 1-5
+FM_MSGD_TO_RC           [16 bytes]  Tier 1-5
+FM_FETCHADD32           [16 bytes]  Tier 1-5
+FM_CAS32                [20 bytes]  Tier 1-5
+FM_DMWR32               [16 bytes]  Tier 1-5
+FM_STREAM_FRAGMENT_0    [48 bytes]  Tier 4 only
+FM_LOCAL_PREFIX_ONLY    [4 bytes]   Tier 2+ (prefix handling)
+```
+
+---
+
+## 8. Negative Test Inventory
+
+| Test | Input | Expected error |
+|---|---|---|
+| `flit_iowr_missing_mandatory_ohc_a2` | FM_IOWR_A2 with byte1=0x00 | `MissingMandatoryOhc` |
+| `flit_cfgwr_missing_mandatory_ohc_a3` | FM_CFGWR0_A3 with byte1=0x00 | `MissingMandatoryOhc` |
+| `flit_mwrpartial_missing_ohc_a1` | FM_MWR32_PARTIAL_A1 minus OHC word + byte1=0x00 | `MissingMandatoryOhc` (optional) |
+| `flit_uiomrd_retyped_invalid` | FM_UIOMRD64_MIN with wrong base size | validator error |
+| `flit_uiomwr_truncated_payload` | FM_UIOMWR64_MIN minus last byte | `InvalidLength` |
+
+---
+
+## 9. Acceptance Criteria
+
+A flit mode implementation is considered complete when:
+
+- [ ] All `#[ignore]` tests in `flit_mode_tests.rs` pass without the `#[ignore]` attribute
+- [ ] All negative tests produce the correct error variant
+- [ ] `FM_STREAM_FRAGMENT_0` stream walk completes with correct offsets
+- [ ] `cargo test` shows 0 ignored tests in `flit_mode_tests.rs`
+- [ ] `TESTS.md` updated with final counts
+- [ ] Version bumped to `0.5.0`

--- a/docs/flit_mode_test_plan.md
+++ b/docs/flit_mode_test_plan.md
@@ -1,6 +1,6 @@
 # Flit Mode Test Plan
 
-**Status:** Planning — implementation pending  
+**Status:** In progress — Tier 1+2 implemented (v0.4.1); Tier 3–5 pending  
 **Target release:** 0.5.0  
 **Reference:** `docs/flit_mode_tlp_examples.md`
 
@@ -226,13 +226,13 @@ and populates fields correctly.
 
 To unlock each tier, these additions to `src/lib.rs` are required:
 
-| Tier | What to add | New public API |
-|---|---|---|
-| 1 | `FlitDW0` struct + `from_dw0()` | `pub struct FlitDW0`, `pub fn flit_dw0_from_bytes()` |
-| 2 | `FlitTlpType` enum + size table | `pub enum FlitTlpType` |
-| 3 | OHC parser + `MissingMandatoryOhc` | `pub struct FlitOhc`, `TlpError::MissingMandatoryOhc` |
-| 4 | Stream walker | `pub struct FlitStreamWalker` or iterator |
-| 5 | `TlpPacket::new_flit()` | wires `TlpMode::Flit` to new parser |
+| Tier | What to add | New public API | Status |
+|---|---|---|---|
+| 1 | `FlitDW0` struct + `from_dw0()` | `pub struct FlitDW0` | ✅ v0.4.1 |
+| 2 | `FlitTlpType` enum + size table | `pub enum FlitTlpType` | ✅ v0.4.1 |
+| 3 | OHC parser + `MissingMandatoryOhc` | `pub struct FlitOhcA`, `TlpError::MissingMandatoryOhc` | 🔜 next |
+| 4 | Stream walker | `pub struct FlitStreamWalker` or iterator | pending |
+| 5 | `TlpPacket::new_flit()` | wires `TlpMode::Flit` to new parser | pending |
 
 Each tier builds on the previous — merge order matters.
 

--- a/docs/flit_mode_test_plan.md
+++ b/docs/flit_mode_test_plan.md
@@ -1,6 +1,6 @@
 # Flit Mode Test Plan
 
-**Status:** In progress — Tier 1+2 implemented (v0.4.1); Tier 3–5 pending  
+**Status:** In progress — Tier 1+2+3 implemented (v0.4.1); Tier 4–5 pending  
 **Target release:** 0.5.0  
 **Reference:** `docs/flit_mode_tlp_examples.md`
 
@@ -154,45 +154,39 @@ These are written and passing NOW.
 
 ---
 
-### Tier 1 — Flit DW0 field extraction `#[ignore]`
+### Tier 1 — Flit DW0 field extraction ✅ (implemented v0.4.1)
 
-Tests that decode individual fields from flit DW0 bytes.  
-Do NOT call `TlpPacket::new` — test a standalone `FlitDW0::from_dw0(bytes)` function.
+Tests that decode individual fields from flit DW0 bytes using `FlitDW0::from_dw0()`.
 
-**Test inputs:** All 15 FM_* vectors (check byte 0, 1, 2, 3 independently).
-
-**Unlock condition:** `FlitDW0` struct and `FlitDW0::from_dw0()` added to `src/lib.rs`.
+**Implemented:** `FlitDW0` struct + `FlitDW0::from_dw0()` in `src/lib.rs`.
 
 ---
 
-### Tier 2 — Per-vector header + size validation `#[ignore]`
+### Tier 2 — Per-vector header + size validation ✅ (implemented v0.4.1)
 
-Tests that each FM_* vector produces the correct:
-- `FlitTlpType`
-- base header size in bytes
-- OHC count (number of extra DW words)
-- total header size = (base + OHC) × 4 bytes
-- payload length in bytes
-- total TLP size in bytes
+Tests that each FM_* vector produces the correct type, base header size, OHC count, and total TLP size.
 
-**Unlock condition:** `FlitTlpType` enum and type-to-header-size table in `src/lib.rs`.
+**Implemented:** `FlitTlpType` enum + `base_header_dw()` + `total_bytes()` in `src/lib.rs`.
 
 ---
 
-### Tier 3 — OHC field parsing `#[ignore]`
+### Tier 3 — OHC field parsing ✅ (implemented v0.4.1)
 
 Tests that OHC words are parsed correctly:
 
-- `FM_MRD32_A1_PASID` → OHC-A1 present, PASID=0x12345, fdwbe=0xF, ldwbe=0x0
-- `FM_MWR32_PARTIAL_A1` → OHC-A1 present, fdwbe=0x3
-- `FM_IOWR_A2` → mandatory OHC-A2 present, fdwbe=0xF
-- `FM_CFGWR0_A3` → mandatory OHC-A3 present
+- `FM_MRD32_A1_PASID` → OHC-A1 present, PASID=0x12345, fdwbe=0xF, ldwbe=0x0 ✅
+- `FM_MWR32_PARTIAL_A1` → OHC-A1 present, fdwbe=0x3 ✅
+- `FM_IOWR_A2` → mandatory OHC-A2 present, fdwbe=0xF ✅
+- `FM_CFGWR0_A3` → mandatory OHC-A3 present ✅
 
 **Negative tests** (mandatory OHC validation):
-- `FM_IOWR_A2` with byte1=0x00 → `Err(TlpError::MissingMandatoryOhc)` (new error variant needed)
-- `FM_CFGWR0_A3` with byte1=0x00 → same error
+- `FM_IOWR_A2` with byte1=0x00 → `Err(TlpError::MissingMandatoryOhc)` ✅
+- `FM_CFGWR0_A3` with byte1=0x00 → same error ✅
 
-**Unlock condition:** OHC parser + `TlpError::MissingMandatoryOhc` variant.
+**Implemented:** `FlitOhcA::from_bytes()` + `FlitDW0::validate_mandatory_ohc()` + `TlpError::MissingMandatoryOhc`.
+
+> **Naming note:** The struct is `FlitOhcA` (not `FlitOhc` as originally planned) to reflect that it
+> parses the OHC-A word specifically (OHC-A1, OHC-A2, OHC-A3 share the same byte layout).
 
 ---
 
@@ -230,7 +224,7 @@ To unlock each tier, these additions to `src/lib.rs` are required:
 |---|---|---|---|
 | 1 | `FlitDW0` struct + `from_dw0()` | `pub struct FlitDW0` | ✅ v0.4.1 |
 | 2 | `FlitTlpType` enum + size table | `pub enum FlitTlpType` | ✅ v0.4.1 |
-| 3 | OHC parser + `MissingMandatoryOhc` | `pub struct FlitOhcA`, `TlpError::MissingMandatoryOhc` | 🔜 next |
+| 3 | OHC parser + `MissingMandatoryOhc` | `pub struct FlitOhcA`, `TlpError::MissingMandatoryOhc` | ✅ v0.4.1 |
 | 4 | Stream walker | `pub struct FlitStreamWalker` or iterator | pending |
 | 5 | `TlpPacket::new_flit()` | wires `TlpMode::Flit` to new parser | pending |
 

--- a/docs/flit_mode_tlp_examples.md
+++ b/docs/flit_mode_tlp_examples.md
@@ -1,0 +1,759 @@
+# flit_mode_tlp_examples.md
+
+This file collects **Flit Mode TLP byte vectors** intended for parser-oriented unit tests in `rust_tlplib`.
+
+These examples are **TLP byte streams as they appear inside the TLP region of a PCIe 6.x FLIT**. They are **not full 256-byte FLIT containers** and therefore do **not** include DLP, CRC, or FEC bytes.
+
+## Scope and verification notes
+
+What is checked here:
+
+- Flit Mode uses a fully decoded `Type[7:0]` field.
+- The examples below only use public Type encodings that are visible in publicly available PCIe 6.x material.
+- `DW0` is encoded as:
+  - `Byte 0 = Type[7:0]`
+  - `Byte 1 = TC[2:0] | OHC[4:0]`
+  - `Byte 2 = TS[2:0] | Attr[2:0] | Length[9:8]`
+  - `Byte 3 = Length[7:0]`
+- All examples use `TC=0`, `TS=0`, `Attr=0`.
+- OHC presence encoding used here:
+  - `0x00` => no OHC
+  - `0x01` => OHC-A present
+- `OHC-A1` is used only when we want explicit byte enables and/or PASID.
+- `OHC-A2` is used for I/O Request examples.
+- `OHC-A3` is used for Configuration Request examples.
+- The UIO examples are included as a **PCIe 6.1+ / UIO-ECN** extension test case.
+
+Important constraint:
+
+Publicly available sources are good enough to validate the **Type code**, **header-base size**, **mandatory OHC rules**, and the **OHC word layout** used below. Public sources do **not** expose every normative bit slice for every non-`DW0` base-header field as completely as the licensed PCIe Base Specification tables do.
+
+Because of that, many examples intentionally keep `DW1` and the route words zero-filled. This still gives you useful, parser-stable vectors for:
+
+- Flit `Type[7:0]` decoding
+- header-base size selection
+- OHC presence / OHC count handling
+- mandatory-OHC validation
+- payload-length handling
+- total-TLP-size calculation in a packed byte stream
+
+I intentionally did **not** freeze `Cpl/CplD/UIORdCplD` golden vectors here because I could not justify the full non-`DW0` completion-field packing from public material strongly enough for a “golden” unit-test document.
+
+## Conventions used below
+
+- Byte order is the on-the-wire byte order: `DW0`, then `DW1`, then `DW2`, ...
+- For address-routed examples, address/route words are often all zero to keep the vector independent of exact non-public field slicing while still remaining parser-usable.
+- Payload bytes are arbitrary and chosen for easy visual recognition.
+
+## Quick reference
+
+| Name | Type | Base header | OHC | Payload | Total bytes | Notes |
+|---|---:|---:|---:|---:|---:|---|
+| `FM_NOP` | `0x00` | 1 DW | 0 DW | 0 DW | 4 | Flit-mode NOP |
+| `FM_MRD32_MIN` | `0x03` | 3 DW | 0 DW | 0 DW | 12 | Minimal 32-bit Memory Read |
+| `FM_MRD32_A1_PASID` | `0x03` | 3 DW | 1 DW | 0 DW | 16 | Memory Read with OHC-A1 + PASID |
+| `FM_MWR32_MIN` | `0x40` | 3 DW | 0 DW | 1 DW | 16 | Minimal 32-bit Memory Write |
+| `FM_MWR32_PARTIAL_A1` | `0x40` | 3 DW | 1 DW | 1 DW | 20 | Partial-byte Memory Write using OHC-A1 |
+| `FM_IOWR_A2` | `0x42` | 3 DW | 1 DW | 1 DW | 20 | I/O Write, mandatory OHC-A2 |
+| `FM_CFGWR0_A3` | `0x44` | 3 DW | 1 DW | 1 DW | 20 | Type0 Config Write, mandatory OHC-A3 |
+| `FM_UIOMRD64_MIN` | `0x22` | 4 DW | 0 DW | 0 DW | 16 | UIO Memory Read, 64-bit header |
+| `FM_UIOMWR64_MIN` | `0x61` | 4 DW | 0 DW | 2 DW | 24 | UIO Memory Write, 64-bit header |
+| `FM_MSG_TO_RC` | `0x30` | 3 DW | 0 DW | 0 DW | 12 | Message routed to RC |
+| `FM_MSGD_TO_RC` | `0x70` | 3 DW | 0 DW | 1 DW | 16 | Message with Data routed to RC |
+| `FM_FETCHADD32` | `0x4C` | 3 DW | 0 DW | 1 DW | 16 | 32-bit FetchAdd AtomicOp |
+| `FM_CAS32` | `0x4E` | 3 DW | 0 DW | 2 DW | 20 | 32-bit Compare-and-Swap AtomicOp |
+| `FM_DMWR32` | `0x5B` | 3 DW | 0 DW | 1 DW | 16 | 32-bit Deferrable Memory Write |
+| `FM_STREAM_FRAGMENT_0` | mixed | mixed | mixed | mixed | 48 | Back-to-back TLP stream fragment |
+
+---
+
+## 1) `FM_NOP`
+
+**What it is**
+
+A Flit Mode `NOP` TLP. Useful as the smallest possible header-base object in a packed stream.
+
+- Type: `NOP`
+- Type code: `0x00`
+- Base header: `1 DW`
+- Length: `0 DW`
+- OHC: none
+
+**Bytes**
+
+```text
+00 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_NOP: [u8; 4] = [
+    0x00, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `NOP`
+- base header size == `1 DW`
+- no payload
+- total size == `4 bytes`
+
+---
+
+## 2) `FM_MRD32_MIN`
+
+**What it is**
+
+A minimal **32-bit Memory Read Request** with `Length=1 DW`, no OHC, and zero-filled route/requester fields.
+
+This is useful for checking that a read request with non-zero `Length` still has **no data payload**.
+
+- Type: `MRd` (32-bit)
+- Type code: `0x03`
+- Base header: `3 DW`
+- Length: `1 DW`
+- OHC: none
+
+**Bytes**
+
+```text
+03 00 00 01  00 00 00 00  00 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_MRD32_MIN: [u8; 12] = [
+    0x03, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MRd32`
+- base header size == `3 DW`
+- OHC count == `0`
+- length field == `1 DW`
+- payload length == `0 bytes`
+- total size == `12 bytes`
+
+---
+
+## 3) `FM_MRD32_A1_PASID`
+
+**What it is**
+
+A 32-bit Memory Read Request carrying **OHC-A1**.
+
+This vector is useful because it exercises:
+
+- `OHC-A` presence in `DW0`
+- `OHC-A1` parsing
+- PASID extraction
+- explicit byte-enable extraction
+
+Here the OHC-A1 word is encoded as:
+
+- flags (`NW/PV/PMR/ER`) = `0`
+- PASID = `0x12345`
+- First DW BE = `0xF`
+- Last DW BE = `0x0`
+
+**Bytes**
+
+```text
+03 01 00 01  00 00 00 00  00 00 00 00  01 23 45 0F
+```
+
+**Rust**
+
+```rust
+pub const FM_MRD32_A1_PASID: [u8; 16] = [
+    0x03, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x01, 0x23, 0x45, 0x0F,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MRd32`
+- OHC-A present
+- OHC-A1 PASID == `0x12345`
+- first DW BE == `0xF`
+- last DW BE == `0x0`
+- total size == `16 bytes`
+
+---
+
+## 4) `FM_MWR32_MIN`
+
+**What it is**
+
+A minimal **32-bit Memory Write Request** with a single `DW` payload and no OHC.
+
+Because `OHC-A1` is absent, this is the clean “default full-byte-enable” write case.
+
+- Type: `MWr` (32-bit)
+- Type code: `0x40`
+- Base header: `3 DW`
+- Length: `1 DW`
+- OHC: none
+- Payload: `DE AD BE EF`
+
+**Bytes**
+
+```text
+40 00 00 01  00 00 00 00  00 00 00 00  DE AD BE EF
+```
+
+**Rust**
+
+```rust
+pub const FM_MWR32_MIN: [u8; 16] = [
+    0x40, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xDE, 0xAD, 0xBE, 0xEF,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MWr32`
+- base header size == `3 DW`
+- payload length == `4 bytes`
+- total size == `16 bytes`
+
+---
+
+## 5) `FM_MWR32_PARTIAL_A1`
+
+**What it is**
+
+A 32-bit Memory Write Request with **OHC-A1** used to carry explicit byte enables for a **partial first-DW write**.
+
+`OHC-A1 = 00 00 00 03` means:
+
+- PASID = `0`
+- First DW BE = `0x3`
+- Last DW BE = `0x0`
+
+This is a good parser test for “Memory Request + OHC-A1 present”.
+
+**Bytes**
+
+```text
+40 01 00 01  00 00 00 00  00 00 00 00  00 00 00 03  AA BB CC DD
+```
+
+**Rust**
+
+```rust
+pub const FM_MWR32_PARTIAL_A1: [u8; 20] = [
+    0x40, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x03,
+    0xAA, 0xBB, 0xCC, 0xDD,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MWr32`
+- OHC-A present
+- OHC-A1 first DW BE == `0x3`
+- payload length == `4 bytes`
+- total size == `20 bytes`
+
+---
+
+## 6) `FM_IOWR_A2`
+
+**What it is**
+
+An **I/O Write Request** with the required **OHC-A2**.
+
+This is an important validation case because **I/O Requests require OHC-A2** in Flit Mode.
+
+Here the OHC-A2 word is:
+
+- reserved bytes = `0`
+- Last DW BE = `0x0`
+- First DW BE = `0xF`
+
+**Bytes**
+
+```text
+42 01 00 01  00 00 00 00  00 00 00 00  00 00 00 0F  10 20 30 40
+```
+
+**Rust**
+
+```rust
+pub const FM_IOWR_A2: [u8; 20] = [
+    0x42, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0F,
+    0x10, 0x20, 0x30, 0x40,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `IOWr`
+- OHC-A present
+- parser infers `OHC-A2` from I/O Request type
+- first DW BE == `0xF`
+- total size == `20 bytes`
+
+**Easy negative test mutation**
+
+Set `DW0[1]` from `0x01` to `0x00`. That should become an **invalid I/O Request** because the required `OHC-A2` is missing.
+
+---
+
+## 7) `FM_CFGWR0_A3`
+
+**What it is**
+
+A **Type 0 Configuration Write Request** with required **OHC-A3**.
+
+This is another mandatory-OHC validation vector.
+
+The OHC-A3 word is zero-filled except for full-byte-enable encoding:
+
+- Destination Segment = `0`
+- DSV = `0`
+- Last DW BE = `0x0`
+- First DW BE = `0xF`
+
+**Bytes**
+
+```text
+44 01 00 01  00 00 00 00  00 00 00 00  00 00 00 0F  44 33 22 11
+```
+
+**Rust**
+
+```rust
+pub const FM_CFGWR0_A3: [u8; 20] = [
+    0x44, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0F,
+    0x44, 0x33, 0x22, 0x11,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `CfgWr0`
+- OHC-A present
+- parser infers `OHC-A3` from Configuration Request type
+- total size == `20 bytes`
+
+**Easy negative test mutation**
+
+Set `DW0[1]` from `0x01` to `0x00`. That should become an **invalid Configuration Request** because the required `OHC-A3` is missing.
+
+---
+
+## 8) `FM_UIOMRD64_MIN`
+
+**What it is**
+
+A minimal **UIO Memory Read Request**.
+
+UIO is a newer extension (PCIe 6.1+ / UIO ECN), and address-routed UIO requests use the **64-bit address format**, so this example uses a `4 DW` base header.
+
+This vector is intentionally minimal and zero-filled outside `DW0`.
+
+- Type: `UIOMRd`
+- Type code: `0x22`
+- Base header: `4 DW`
+- Length: `2 DW`
+- OHC: none
+
+**Bytes**
+
+```text
+22 00 00 02  00 00 00 00  00 00 00 00  00 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_UIOMRD64_MIN: [u8; 16] = [
+    0x22, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `UIOMRd`
+- base header size == `4 DW`
+- no payload even though `Length=2 DW`
+- total size == `16 bytes`
+
+---
+
+## 9) `FM_UIOMWR64_MIN`
+
+**What it is**
+
+A minimal **UIO Memory Write Request**.
+
+This is the requested new UIO-family test case for the library.
+
+- Type: `UIOMWr`
+- Type code: `0x61`
+- Base header: `4 DW`
+- Length: `2 DW`
+- OHC: none
+- Payload: `11 22 33 44 55 66 77 88`
+
+**Bytes**
+
+```text
+61 00 00 02  00 00 00 00  00 00 00 00  00 00 00 00  11 22 33 44  55 66 77 88
+```
+
+**Rust**
+
+```rust
+pub const FM_UIOMWR64_MIN: [u8; 24] = [
+    0x61, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x11, 0x22, 0x33, 0x44,
+    0x55, 0x66, 0x77, 0x88,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `UIOMWr`
+- base header size == `4 DW`
+- payload length == `8 bytes`
+- total size == `24 bytes`
+
+---
+
+## 10) `FM_MSG_TO_RC`
+
+**What it is**
+
+A Message Request with no data, using the **“routed to RC”** flit-mode Type code.
+
+- Type: `Msg, route to RC`
+- Type code: `0x30`
+- Base header: `3 DW`
+- Length: `0 DW`
+
+**Bytes**
+
+```text
+30 00 00 00  00 00 00 00  00 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_MSG_TO_RC: [u8; 12] = [
+    0x30, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MsgToRc`
+- no payload
+- total size == `12 bytes`
+
+---
+
+## 11) `FM_MSGD_TO_RC`
+
+**What it is**
+
+A Message Request **with data**, routed to the RC.
+
+- Type: `MsgD, route to RC`
+- Type code: `0x70`
+- Base header: `3 DW`
+- Length: `1 DW`
+- Payload: `AA 55 AA 55`
+
+**Bytes**
+
+```text
+70 00 00 01  00 00 00 00  00 00 00 00  AA 55 AA 55
+```
+
+**Rust**
+
+```rust
+pub const FM_MSGD_TO_RC: [u8; 16] = [
+    0x70, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xAA, 0x55, 0xAA, 0x55,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `MsgDToRc`
+- payload length == `4 bytes`
+- total size == `16 bytes`
+
+---
+
+## 12) `FM_FETCHADD32`
+
+**What it is**
+
+A 32-bit **FetchAdd AtomicOp Request**.
+
+- Type: `FetchAdd` (32-bit)
+- Type code: `0x4C`
+- Base header: `3 DW`
+- Length: `1 DW`
+- Payload operand: `01 00 00 00`
+
+**Bytes**
+
+```text
+4C 00 00 01  00 00 00 00  00 00 00 00  01 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_FETCHADD32: [u8; 16] = [
+    0x4C, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `FetchAdd32`
+- payload length == `4 bytes`
+- total size == `16 bytes`
+
+---
+
+## 13) `FM_CAS32`
+
+**What it is**
+
+A 32-bit **Compare-and-Swap AtomicOp Request**.
+
+`CAS` is useful because it carries a `2 DW` payload.
+
+- Type: `CAS` (32-bit)
+- Type code: `0x4E`
+- Base header: `3 DW`
+- Length: `2 DW`
+- Payload: compare value then swap value
+
+**Bytes**
+
+```text
+4E 00 00 02  00 00 00 00  00 00 00 00  11 11 11 11  22 22 22 22
+```
+
+**Rust**
+
+```rust
+pub const FM_CAS32: [u8; 20] = [
+    0x4E, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x11, 0x11, 0x11, 0x11,
+    0x22, 0x22, 0x22, 0x22,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `CAS32`
+- payload length == `8 bytes`
+- total size == `20 bytes`
+
+---
+
+## 14) `FM_DMWR32`
+
+**What it is**
+
+A **32-bit Deferrable Memory Write Request**.
+
+This is worth keeping because your current crate already has `DMWr` support on the non-flit side, so it is a natural flit-mode parser target too.
+
+- Type: `DMWr` (32-bit)
+- Type code: `0x5B`
+- Base header: `3 DW`
+- Length: `1 DW`
+- Payload: `C0 FF EE 00`
+
+**Bytes**
+
+```text
+5B 00 00 01  00 00 00 00  00 00 00 00  C0 FF EE 00
+```
+
+**Rust**
+
+```rust
+pub const FM_DMWR32: [u8; 16] = [
+    0x5B, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xC0, 0xFF, 0xEE, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- flit type == `DMWr32`
+- payload length == `4 bytes`
+- total size == `16 bytes`
+
+---
+
+## 15) `FM_STREAM_FRAGMENT_0`
+
+**What it is**
+
+A **packed byte stream fragment** containing multiple back-to-back flit-mode TLPs.
+
+This is not a full FLIT container. It is meant to test the parser’s ability to walk a packed TLP stream using:
+
+- decoded `Type[7:0]`
+- base header size
+- OHC count
+- payload length
+
+Contained sequence:
+
+1. `FM_NOP`
+2. `FM_MRD32_MIN`
+3. `FM_MWR32_MIN`
+4. `FM_UIOMRD64_MIN`
+
+**Bytes**
+
+```text
+00 00 00 00
+03 00 00 01  00 00 00 00  00 00 00 00
+40 00 00 01  00 00 00 00  00 00 00 00  DE AD BE EF
+22 00 00 02  00 00 00 00  00 00 00 00  00 00 00 00
+```
+
+**Rust**
+
+```rust
+pub const FM_STREAM_FRAGMENT_0: [u8; 48] = [
+    0x00, 0x00, 0x00, 0x00,
+
+    0x03, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+
+    0x40, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xDE, 0xAD, 0xBE, 0xEF,
+
+    0x22, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+```
+
+**Suggested parser checks**
+
+- first object parsed as `NOP`, size `4`
+- second object starts at offset `4`, parsed as `MRd32`, size `12`
+- third object starts at offset `16`, parsed as `MWr32`, size `16`
+- fourth object starts at offset `32`, parsed as `UIOMRd`, size `16`
+- end offset == `48`
+
+---
+
+## Appendix A) Prefix token for later parser work
+
+This one is useful if you later add flit-prefix parsing. It is **not** a stand-alone request/completion transaction by itself; it is a prefix object.
+
+### `FM_LOCAL_PREFIX_ONLY`
+
+- Type: `FlitMode Local TLP Prefix`
+- Type code: `0x8D`
+- Base header: `1 DW`
+- No payload in this minimal token example
+
+```text
+8D 00 00 00
+```
+
+```rust
+pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
+    0x8D, 0x00, 0x00, 0x00,
+];
+```
+
+---
+
+## Negative-test ideas derived from the valid vectors
+
+These are straightforward parser-negative cases you can create by mutating the valid vectors above:
+
+1. `FM_IOWR_A2` with `DW0[1]=0x00`
+   - should fail mandatory `OHC-A2` validation
+
+2. `FM_CFGWR0_A3` with `DW0[1]=0x00`
+   - should fail mandatory `OHC-A3` validation
+
+3. `FM_MWR32_PARTIAL_A1` with the OHC word removed but `DW0[1]=0x00`
+   - should fail if your semantic validator insists that explicit partial-byte memory accesses require `OHC-A1`
+
+4. `FM_UIOMRD64_MIN` re-typed to a non-64b request form
+   - should fail a UIO-specific validator if you enforce the 64-bit-address requirement for address-routed UIO requests
+
+5. Truncate the final payload byte from `FM_UIOMWR64_MIN`
+   - should fail total-size / payload-length checks
+
+---
+
+## Not frozen yet
+
+I would **not** use the following as golden vectors until you validate them against the exact PCIe Base Spec revision you target:
+
+- `Cpl`
+- `CplD`
+- `UIORdCplD`
+- vectors using `OHC-A5`
+- vectors using `OHC-B` / `OHC-C`
+- IDE trailer examples
+- non-zero 10-bit / 14-bit Tag packing tests
+
+Those are all reasonable next additions once you are ready to lock the exact bit-level layout for the remaining flit-mode fields.

--- a/docs/non-flitmode.md
+++ b/docs/non-flitmode.md
@@ -1,0 +1,207 @@
+# API Proposal: Non-Flit Mode / Flit Mode Split
+
+**Status:** Draft — for review and discussion
+**Target release:** 0.4.0 or 0.5.0 (see [Decision Points](#decision-points))
+
+---
+
+## Background
+
+The current library was built explicitly for **non-flit mode** TLPs (PCIe 1.0–5.0).
+PCIe 6.0 introduced **flit mode**, where TLPs are carried inside fixed 256-byte
+flit containers with different framing, CRC, and packing rules.
+
+The TLP header fields themselves are largely unchanged between modes — what differs
+is how raw bytes are extracted and validated before header parsing begins. This
+proposal introduces a `TlpMode` abstraction at the entry point so the library can
+support both modes without breaking callers again in a future release.
+
+---
+
+## Problem with the current API
+
+```rust
+TlpPacket::new(bytes: Vec<u8>) -> Result<TlpPacket, TlpError>
+```
+
+`TlpPacket::new` takes raw bytes with no concept of where they came from or how
+they should be interpreted. Adding flit mode later would require either:
+
+- A new constructor (`TlpPacket::new_flit(...)`) — inconsistent, hard to use generically
+- A breaking change to the existing constructor — forces another major bump
+- A wrapper type that duplicates the existing API
+
+All three options are worse than introducing `TlpMode` now while 0.4.0 is already
+a breaking release.
+
+---
+
+## Proposed Changes
+
+### 1. New `TlpMode` enum
+
+```rust
+/// Selects the framing mode used to interpret the raw byte buffer.
+///
+/// Non-flit mode covers PCIe 1.0 through 5.0. Flit mode was introduced
+/// in PCIe 6.0 and uses fixed 256-byte containers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TlpMode {
+    /// Standard non-flit TLP framing (PCIe 1.0 – 5.0).
+    /// Bytes are interpreted directly as a TLP header followed by optional payload.
+    NonFlit,
+
+    /// Flit-mode TLP framing (PCIe 6.0+).
+    /// Not yet implemented — returns `Err(TlpError::NotImplemented)`.
+    Flit,
+}
+```
+
+`#[non_exhaustive]` is important here — it prevents downstream `match` arms from
+being exhaustive, so adding future variants (e.g. `FlitCompressed`) is not a
+breaking change.
+
+---
+
+### 2. Updated `TlpPacket::new`
+
+```rust
+impl TlpPacket {
+    pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacket, TlpError> {
+        match mode {
+            TlpMode::NonFlit => Self::new_non_flit(bytes),
+            TlpMode::Flit => Err(TlpError::NotImplemented),
+        }
+    }
+}
+```
+
+Current behavior moves into `new_non_flit` unchanged. Callers update to:
+
+```rust
+// before (0.4.0)
+let pkt = TlpPacket::new(bytes).unwrap();
+
+// after (proposed)
+let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
+```
+
+---
+
+### 3. New `TlpError` variant
+
+```rust
+pub enum TlpError {
+    InvalidFormat,
+    InvalidType,
+    InvalidLength,
+    UnsupportedCombination,
+    NotImplemented,   // ← new: feature exists in the API but not yet implemented
+}
+```
+
+---
+
+### 4. Factory functions — no change needed
+
+`new_mem_req`, `new_conf_req`, `new_cmpl_req`, `new_msg_req`, `new_atomic_req`
+all operate on pre-extracted bytes passed in by the caller. They are mode-agnostic
+at this level — the mode only affects how `TlpPacket` unpacks the raw buffer.
+No changes required to these signatures.
+
+---
+
+### 5. `TlpPacketHeader::new` — same treatment
+
+```rust
+impl TlpPacketHeader {
+    pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacketHeader, TlpError>
+}
+```
+
+Mirrors `TlpPacket::new` for consistency.
+
+---
+
+## What flit mode implementation would look like (future)
+
+When `TlpMode::Flit` is eventually implemented, `new_non_flit` / `new_flit`
+become separate parse paths under the same public constructor:
+
+```
+Flit container (256 bytes)
+  └── Flit header (8 bytes: slot count, CRC, ...)
+  └── Slot 0: TLP bytes  ──→  existing header parsing (DW0..DWn)
+  └── Slot 1: TLP bytes  ──→  existing header parsing
+  └── Null padding
+```
+
+The per-TLP header parsing (everything below `TlpPacket`) is reused unchanged.
+Only the framing/extraction layer differs.
+
+---
+
+## Migration guide (0.4.0 → proposed)
+
+| Before | After |
+|---|---|
+| `TlpPacket::new(bytes)` | `TlpPacket::new(bytes, TlpMode::NonFlit)` |
+| `TlpPacketHeader::new(bytes)` | `TlpPacketHeader::new(bytes, TlpMode::NonFlit)` |
+| `TlpError` match arms | Add `TlpError::NotImplemented` arm (or use `_`) |
+
+All other public API (`TlpFmt`, `TlpType`, all traits, all factory functions)
+is unchanged.
+
+---
+
+## Decision Points
+
+### Should this land in 0.4.0 or 0.5.0?
+
+**0.4.0 (recommended):**
+- 0.4.0 is already a breaking release — the additional migration cost is two
+  call sites per constructor, trivially mechanical
+- Avoids a 0.5.0 break immediately after 0.4.0
+- `TlpMode::Flit` can stub out as `NotImplemented` with no implementation risk
+
+**0.5.0:**
+- Gives more time to validate the `TlpMode` design against real flit-mode specs
+- Keeps 0.4.0 diff smaller and easier to review
+- Acceptable if flit mode is genuinely far off and the `TlpMode` shape might change
+
+### Should `TlpMode` be a constructor parameter or a type parameter?
+
+The proposal uses a runtime parameter. An alternative is a type-level split:
+
+```rust
+// type-parameter approach
+TlpPacket<NonFlit>
+TlpPacket<Flit>
+```
+
+This has appeal for zero-cost mode dispatch and makes it impossible to mix modes
+at compile time. However it propagates the type parameter into every trait bound
+and factory function signature, which is significant API complexity. The runtime
+parameter is simpler and sufficient given the modes are not performance-critical.
+
+### Should callers ever need to handle flit unpacking themselves?
+
+If the library only does TLP parsing and not flit container parsing, callers on
+PCIe 6.0 would be expected to extract TLP bytes from flits themselves before
+calling `TlpPacket::new(bytes, TlpMode::NonFlit)`. This is a valid design since
+flit framing is a layer below TLP semantics.
+
+Alternatively, the library could expose a `FlitContainer` type that yields an
+iterator of `TlpPacket`s. This is more ambitious and should be a separate
+design discussion.
+
+---
+
+## Open Questions
+
+1. Should `TlpMode::Flit` return `NotImplemented` or should the variant simply
+   not exist until the implementation is ready?
+2. Is flit container parsing in scope for this library at all, or out of scope
+   by design?
+3. Are there PCIe 6.0 traces available to validate flit parsing against?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1503,7 +1503,7 @@ mod tests {
         let bytes = vec![0x00, 0x00, 0x00, 0x00];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
         assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
-        assert!(pkt.get_data().is_empty());
+        assert!(pkt.data().is_empty());
     }
 
     #[test]
@@ -1512,7 +1512,7 @@ mod tests {
         let bytes = vec![0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
         assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
-        assert!(pkt.get_data().is_empty()); // read request, no payload
+        assert!(pkt.data().is_empty()); // read request, no payload
     }
 
     #[test]
@@ -1526,7 +1526,7 @@ mod tests {
         ];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
         assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
-        assert_eq!(pkt.get_data(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(pkt.data(), [0xDE, 0xAD, 0xBE, 0xEF]);
     }
 
     #[test]
@@ -1766,7 +1766,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
-        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap()).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &pkt.get_tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xABCD);
         assert_eq!(mr.tag(),    0x42);
         assert_eq!(mr.address(), 0xDEAD_0000);
@@ -1784,7 +1784,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
-        let mr = new_mem_req(pkt.get_data(), &pkt.get_tlp_format().unwrap()).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &pkt.get_tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xBEEF);
         assert_eq!(mr.tag(),    0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);
@@ -1849,7 +1849,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
         let fmt = pkt.get_tlp_format().unwrap();
-        let mr = new_mem_req(pkt.get_data(), &fmt).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0x1234);
         assert_eq!(mr.tag(),     0x56);
         assert_eq!(mr.address(), 0x89AB_CDEF);
@@ -1878,7 +1878,7 @@ mod tests {
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
         let fmt = pkt.get_tlp_format().unwrap();
-        let mr = new_mem_req(pkt.get_data(), &fmt).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0xBEEF);
         assert_eq!(mr.tag(),     0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,9 @@ impl Display for TlpType {
 
 impl TlpType {
     /// Returns `true` for non-posted TLP types (requests that expect a Completion).
+    ///
+    /// Non-posted transactions include memory reads, I/O, configuration, atomics,
+    /// and Deferrable Memory Write. Posted writes (`MemWriteReq`, messages) return `false`.
     pub fn is_non_posted(&self) -> bool {
         matches!(self,
             TlpType::MemReadReq |
@@ -214,6 +217,23 @@ impl TlpType {
             TlpType::FetchAddAtomicOpReq | TlpType::SwapAtomicOpReq | TlpType::CompareSwapAtomicOpReq |
             TlpType::DeferrableMemWriteReq
         )
+    }
+
+    /// Returns `true` for posted TLP types (no Completion expected).
+    ///
+    /// Convenience inverse of [`TlpType::is_non_posted`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rtlp_lib::TlpType;
+    ///
+    /// assert!(TlpType::MemWriteReq.is_posted());    // posted write
+    /// assert!(TlpType::MsgReq.is_posted());         // message
+    /// assert!(!TlpType::MemReadReq.is_posted());    // non-posted
+    /// ```
+    pub fn is_posted(&self) -> bool {
+        !self.is_non_posted()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{self, Display};
 
 use bitfield::bitfield;
 
@@ -48,15 +48,15 @@ pub enum TlpFmt {
 }
 
 impl Display for TlpFmt {
-    fn fmt (&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
-        let name = match &self {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
             TlpFmt::NoDataHeader3DW => "3DW no Data Header",
             TlpFmt::NoDataHeader4DW => "4DW no Data Header",
             TlpFmt::WithDataHeader3DW => "3DW with Data Header",
             TlpFmt::WithDataHeader4DW => "4DW with Data Header",
             TlpFmt::TlpPrefix => "Tlp Prefix",
         };
-        write!(fmt, "{}", name)
+        write!(f, "{name}")
     }
 }
 
@@ -153,8 +153,8 @@ pub enum TlpType {
 }
 
 impl Display for TlpType {
-    fn fmt (&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
-        let name = match &self {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
             TlpType::MemReadReq => "Memory Read Request",
             TlpType::MemReadLockReq => "Locked Memory Read Request",
             TlpType::MemWriteReq => "Memory Write Request",
@@ -177,7 +177,7 @@ impl Display for TlpType {
             TlpType::LocalTlpPrefix => "Local Tlp Prefix",
             TlpType::EndToEndTlpPrefix => "End To End Tlp Prefix",
         };
-        write!(fmt, "{}", name)
+        write!(f, "{name}")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,9 @@ pub(crate) enum TlpFormatEncodingType {
     UnconSwapAtomicOpRequest= 0b01101,
     CompSwapAtomicOpRequest = 0b01110,
     DeferrableMemoryWriteRequest = 0b11011,
+    /// Message Request — covers all 6 routing sub-types (0b10000..=0b10101).
+    /// Fmt=000/001 → MsgReq, Fmt=010/011 → MsgReqData.
+    MessageRequest          = 0b10000,
 }
 
 impl TryFrom<u32> for TlpFormatEncodingType {
@@ -136,6 +139,9 @@ impl TryFrom<u32> for TlpFormatEncodingType {
             0b01101 => Ok(TlpFormatEncodingType::UnconSwapAtomicOpRequest),
             0b01110 => Ok(TlpFormatEncodingType::CompSwapAtomicOpRequest),
             0b11011 => Ok(TlpFormatEncodingType::DeferrableMemoryWriteRequest),
+            // All message routing sub-types: route-to-RC, by-addr, by-ID,
+            // broadcast, local, gathered — Type[4:3]=10, bits[2:0]=routing
+            0b10000..=0b10101 => Ok(TlpFormatEncodingType::MessageRequest),
             _       => Err(TlpError::InvalidType),
         }
     }
@@ -235,6 +241,16 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
         let tlp_type = self.get_type();
         let tlp_fmt = self.get_format();
 
+        // TLP Prefix is identified by Fmt=0b100 alone, regardless of the Type field.
+        // Type[4]=0 → Local TLP Prefix; Type[4]=1 → End-to-End TLP Prefix.
+        if let Ok(TlpFmt::TlpPrefix) = TlpFmt::try_from(tlp_fmt) {
+            return if tlp_type & 0b10000 != 0 {
+                Ok(TlpType::EndToEndTlpPrefix)
+            } else {
+                Ok(TlpType::LocalTlpPrefix)
+            };
+        }
+
         match TlpFormatEncodingType::try_from(tlp_type) {
             Ok(TlpFormatEncodingType::MemoryRequest) => {
                 match TlpFmt::try_from(tlp_fmt) {
@@ -322,6 +338,16 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
 				match TlpFmt::try_from(tlp_fmt) {
 					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::DeferrableMemWriteReq),
 					Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::DeferrableMemWriteReq),
+					Ok(_) => Err(TlpError::UnsupportedCombination),
+					Err(e) => Err(e),
+				}
+			}
+			// Message Requests: all 6 routing sub-types map here.
+			// Fmt=000/001 (no data) → MsgReq; Fmt=010/011 (with data) → MsgReqData.
+			Ok(TlpFormatEncodingType::MessageRequest) => {
+				match TlpFmt::try_from(tlp_fmt) {
+					Ok(TlpFmt::NoDataHeader3DW) | Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MsgReq),
+					Ok(TlpFmt::WithDataHeader3DW) | Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::MsgReqData),
 					Ok(_) => Err(TlpError::UnsupportedCombination),
 					Err(e) => Err(e),
 				}
@@ -1679,16 +1705,13 @@ mod tests {
         assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_MEM_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
         assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_MEM_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 
-        // TlpPrefix fmt (0b100) is a valid format value but illegal for all
-        // request/completion type encodings — currently hits UnsupportedCombination
-        assert_eq!(dw0(FMT_PREFIX, TY_IO).get_tlp_type().unwrap_err(),   TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_PREFIX, TY_CPL).get_tlp_type().unwrap_err(),  TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_PREFIX, TY_CFG0).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        // TlpPrefix fmt (0b100): all Type values decode to a Prefix type, never UnsupportedCombination.
+        // These are tested in header_decode_prefix_and_message_types.
 
         // DMWr: NoData variants are illegal (DMWr always carries data)
         assert_eq!(dw0(FMT_3DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
         assert_eq!(dw0(FMT_4DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_PREFIX,      TY_DMWR).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        // Note: FMT_PREFIX with TY_DMWR now decodes to EndToEndTlpPrefix (Type[4]=1)
     }
 
     // ── DMWr: Deferrable Memory Write header decode ────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,13 +487,14 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// # let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 /// # decode(bytes).unwrap();
 /// ```
-pub fn new_mem_req(bytes: Vec<u8>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
+pub fn new_mem_req(bytes: impl Into<Vec<u8>>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
+    let bytes = bytes.into();
     match format {
-        TlpFmt::NoDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
-        TlpFmt::NoDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
+        TlpFmt::NoDataHeader3DW   => Ok(Box::new(MemRequest3DW(bytes))),
+        TlpFmt::NoDataHeader4DW   => Ok(Box::new(MemRequest4DW(bytes))),
         TlpFmt::WithDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
         TlpFmt::WithDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
-        TlpFmt::TlpPrefix => Err(TlpError::UnsupportedCombination),
+        TlpFmt::TlpPrefix         => Err(TlpError::UnsupportedCombination),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -841,6 +841,22 @@ impl FlitTlpType {
     pub fn is_read_request(&self) -> bool {
         matches!(self, FlitTlpType::MemRead32 | FlitTlpType::UioMemRead)
     }
+
+    /// Returns `true` for TLP types that carry a data payload in the wire packet.
+    ///
+    /// When `false`, `total_bytes()` ignores the `Length` field and contributes
+    /// zero payload bytes regardless of its value. This covers:
+    /// - Read requests (payload is in the completion, not the request)
+    /// - NOP and Local TLP Prefix (management objects with no data)
+    /// - Message-without-data variants (`MsgToRc`)
+    pub fn has_data_payload(&self) -> bool {
+        matches!(self,
+            FlitTlpType::MemWrite32 | FlitTlpType::UioMemWrite
+            | FlitTlpType::IoWrite | FlitTlpType::CfgWrite0
+            | FlitTlpType::FetchAdd32 | FlitTlpType::CompareSwap32
+            | FlitTlpType::DeferrableMemWrite32 | FlitTlpType::MsgDToRc
+        )
+    }
 }
 
 impl TryFrom<u8> for FlitTlpType {
@@ -922,14 +938,18 @@ impl FlitDW0 {
     /// Total TLP size in bytes:
     /// `(base_header_dw + ohc_count) × 4 + payload_bytes`
     ///
-    /// Read requests carry **no** payload bytes even when `length > 0`.
+    /// Per PCIe spec a `length` value of `0` encodes **1024 DW** (4096 bytes),
+    /// but only for types that actually carry a data payload (see [`FlitTlpType::has_data_payload`]).
+    /// Types that never carry payload (read requests, NOP, LocalTlpPrefix, MsgToRc)
+    /// always contribute zero payload bytes.
     pub fn total_bytes(&self) -> usize {
         let header_bytes = (self.tlp_type.base_header_dw() as usize
             + self.ohc_count() as usize) * 4;
-        let payload_bytes = if self.tlp_type.is_read_request() {
+        let payload_bytes = if !self.tlp_type.has_data_payload() {
             0
         } else {
-            self.length as usize * 4
+            let dw_count = if self.length == 0 { 1024 } else { self.length as usize };
+            dw_count * 4
         };
         header_bytes + payload_bytes
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,27 +490,31 @@ pub trait ConfigurationRequest {
     fn reg_nr(&self) -> u8;
 }
 
-/// Obtain Configuration Request trait from bytes in vector as dyn
+/// Obtain Configuration Request trait from bytes in vector as dyn.
+///
+/// **Note:** The `bytes` slice must contain the full **DW1+DW2 payload** (8 bytes).
+/// `TlpPacket::data()` returns exactly those bytes when the packet was
+/// constructed from a complete 12-byte configuration request header.
 ///
 /// # Examples
 ///
 /// ```
-/// use std::convert::TryFrom;
+/// use rtlp_lib::{TlpPacket, TlpMode, ConfigurationRequest, new_conf_req};
 ///
-/// use rtlp_lib::TlpPacket;
-/// use rtlp_lib::TlpFmt;
-/// use rtlp_lib::TlpMode;
-/// use rtlp_lib::ConfigurationRequest;
-/// use rtlp_lib::new_conf_req;
-///
-/// let bytes = vec![0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+/// // 12 bytes: DW0 (ConfType0WriteReq) + DW1 (req_id, tag, BE) + DW2 (bus/dev/func/reg)
+/// // DW0: 0x44=ConfType0WriteReq, length=1
+/// // DW1: req_id=0x0001, tag=0x00, BE=0x0F
+/// // DW2: bus=0xC2, device=0x10>>3=1, func=0, ext_reg=0, reg=4
+/// let bytes = vec![
+///     0x44, 0x00, 0x00, 0x01,  // DW0
+///     0x00, 0x01, 0x00, 0x0F,  // DW1
+///     0xC2, 0x08, 0x00, 0x10,  // DW2
+/// ];
 /// let tlp = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
-/// if let Ok(tlpfmt) = tlp.get_tlp_format() {
-///     let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.get_data());
-///
-///     //println!("Configuration Request Bus: {:x}", config_req.bus_nr());
-/// }
+/// // data() returns DW1+DW2 (8 bytes) — exactly what ConfigRequest needs
+/// let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.data().to_vec());
+/// assert_eq!(config_req.bus_nr(), 0xC2);
 /// ```
 pub fn new_conf_req(bytes: Vec<u8>) -> Box<dyn ConfigurationRequest> {
 	Box::new(ConfigRequest(bytes))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt::Display;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,6 +753,166 @@ pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpErro
     Ok(Box::new(AtomicReq { op, width, req_id, tag, address, operand0, operand1 }))
 }
 
+// ============================================================================
+// Flit Mode types (PCIe 6.x)
+// ============================================================================
+
+/// TLP type codes used in Flit Mode DW0 byte 0.
+///
+/// These are **completely different** from the non-flit `TlpType` encoding.
+/// In flit mode, `DW0[7:0]` is a flat 8-bit type code rather than the
+/// non-flit `Fmt[2:0] | Type[4:0]` split.
+///
+/// `#[non_exhaustive]` — future type codes will be added without breaking
+/// downstream `match` arms.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FlitTlpType {
+    /// NOP — smallest flit object, 1 DW base header, no payload.
+    Nop,
+    /// 32-bit Memory Read Request (3 DW base header, no payload despite Length field).
+    MemRead32,
+    /// UIO Memory Read — 64-bit address, 4 DW base header (PCIe 6.1+ UIO).
+    UioMemRead,
+    /// Message routed to Root Complex, no data.
+    MsgToRc,
+    /// 32-bit Memory Write Request (3 DW base header + payload).
+    MemWrite32,
+    /// I/O Write Request — requires mandatory OHC-A2.
+    IoWrite,
+    /// Type 0 Configuration Write Request — requires mandatory OHC-A3.
+    CfgWrite0,
+    /// 32-bit FetchAdd AtomicOp Request.
+    FetchAdd32,
+    /// 32-bit Compare-and-Swap AtomicOp Request (2 DW payload).
+    CompareSwap32,
+    /// 32-bit Deferrable Memory Write Request.
+    DeferrableMemWrite32,
+    /// UIO Memory Write — 64-bit address, 4 DW base header (PCIe 6.1+ UIO).
+    UioMemWrite,
+    /// Message with Data routed to Root Complex.
+    MsgDToRc,
+    /// Local TLP Prefix token (1 DW base header).
+    LocalTlpPrefix,
+}
+
+impl FlitTlpType {
+    /// Base header size in DW, **not** counting OHC extension words.
+    ///
+    /// - NOP and LocalTlpPrefix: 1 DW
+    /// - UIO types (64-bit address): 4 DW
+    /// - All other types: 3 DW
+    pub fn base_header_dw(&self) -> u8 {
+        match self {
+            FlitTlpType::Nop | FlitTlpType::LocalTlpPrefix => 1,
+            FlitTlpType::UioMemRead | FlitTlpType::UioMemWrite => 4,
+            _ => 3,
+        }
+    }
+
+    /// Returns `true` for read requests that carry **no payload** even when
+    /// the `Length` field is non-zero.
+    pub fn is_read_request(&self) -> bool {
+        matches!(self, FlitTlpType::MemRead32 | FlitTlpType::UioMemRead)
+    }
+}
+
+impl TryFrom<u8> for FlitTlpType {
+    type Error = TlpError;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0x00 => Ok(FlitTlpType::Nop),
+            0x03 => Ok(FlitTlpType::MemRead32),
+            0x22 => Ok(FlitTlpType::UioMemRead),
+            0x30 => Ok(FlitTlpType::MsgToRc),
+            0x40 => Ok(FlitTlpType::MemWrite32),
+            0x42 => Ok(FlitTlpType::IoWrite),
+            0x44 => Ok(FlitTlpType::CfgWrite0),
+            0x4C => Ok(FlitTlpType::FetchAdd32),
+            0x4E => Ok(FlitTlpType::CompareSwap32),
+            0x5B => Ok(FlitTlpType::DeferrableMemWrite32),
+            0x61 => Ok(FlitTlpType::UioMemWrite),
+            0x70 => Ok(FlitTlpType::MsgDToRc),
+            0x8D => Ok(FlitTlpType::LocalTlpPrefix),
+            _    => Err(TlpError::InvalidType),
+        }
+    }
+}
+
+/// Parsed representation of a flit-mode DW0 (first 4 bytes of a flit TLP).
+///
+/// Flit-mode DW0 layout:
+///
+/// ```text
+/// Byte 0: Type[7:0]            — flat 8-bit type code
+/// Byte 1: TC[2:0] | OHC[4:0]  — traffic class + OHC presence bitmap
+/// Byte 2: TS[2:0] | Attr[2:0] | Length[9:8]
+/// Byte 3: Length[7:0]
+/// ```
+///
+/// Use [`FlitDW0::from_dw0`] to parse from a byte slice.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FlitDW0 {
+    /// Decoded TLP type.
+    pub tlp_type: FlitTlpType,
+    /// Traffic Class (bits [2:0] of byte 1).
+    pub tc: u8,
+    /// OHC presence bitmap (bits [4:0] of byte 1).
+    /// Each set bit indicates one Optional Header Content word appended
+    /// after the base header. Use [`FlitDW0::ohc_count`] for the DW count.
+    pub ohc: u8,
+    /// Transaction Steering (bits [7:5] of byte 2).
+    pub ts: u8,
+    /// Attributes (bits [4:2] of byte 2).
+    pub attr: u8,
+    /// Payload length in DW. A value of `0` encodes 1024 DW.
+    pub length: u16,
+}
+
+impl FlitDW0 {
+    /// Parse the flit-mode DW0 from the first 4 bytes of a byte slice.
+    ///
+    /// Returns `Err(TlpError::InvalidLength)` if `b.len() < 4`.
+    /// Returns `Err(TlpError::InvalidType)` if the type code is unknown.
+    pub fn from_dw0(b: &[u8]) -> Result<Self, TlpError> {
+        if b.len() < 4 {
+            return Err(TlpError::InvalidLength);
+        }
+        let tlp_type = FlitTlpType::try_from(b[0])?;
+        let tc       = (b[1] >> 5) & 0x07;
+        let ohc      = b[1] & 0x1F;
+        let ts       = (b[2] >> 5) & 0x07;
+        let attr     = (b[2] >> 2) & 0x07;
+        let length   = (((b[2] & 0x03) as u16) << 8) | (b[3] as u16);
+        Ok(FlitDW0 { tlp_type, tc, ohc, ts, attr, length })
+    }
+
+    /// Number of OHC extension words present — popcount of [`FlitDW0::ohc`].
+    pub fn ohc_count(&self) -> u8 {
+        self.ohc.count_ones() as u8
+    }
+
+    /// Total TLP size in bytes:
+    /// `(base_header_dw + ohc_count) × 4 + payload_bytes`
+    ///
+    /// Read requests carry **no** payload bytes even when `length > 0`.
+    pub fn total_bytes(&self) -> usize {
+        let header_bytes = (self.tlp_type.base_header_dw() as usize
+            + self.ohc_count() as usize) * 4;
+        let payload_bytes = if self.tlp_type.is_read_request() {
+            0
+        } else {
+            self.length as usize * 4
+        };
+        header_bytes + payload_bytes
+    }
+}
+
+// ============================================================================
+// End of Flit Mode types
+// ============================================================================
+
 /// TLP Packet Header
 /// Contains bytes for Packet header and informations about TLP type
 pub struct TlpPacketHeader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,7 +740,7 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpError> {
     let tlp_type = pkt.get_tlp_type()?;
     let format   = pkt.get_tlp_format()?;
-    let bytes    = pkt.get_data();
+    let bytes    = pkt.data();
 
     let op = match tlp_type {
         TlpType::FetchAddAtomicOpReq    => AtomicOp::FetchAdd,
@@ -1235,12 +1235,21 @@ impl TlpPacket {
         &self.header
     }
 
-    /// Returns the packet payload bytes (everything after the 4-byte DW0 header)
-    /// as an owned `Vec<u8>`.
+    /// Returns the packet payload bytes (everything after the 4-byte DW0 header).
     ///
     /// For flit-mode read requests this will be empty even when `Length > 0`.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the packet payload bytes as an owned `Vec<u8>`.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::data`] which returns `&[u8]` without allocating.
+    #[deprecated(since = "0.6.0", note = "use data() which returns &[u8] instead")]
     pub fn get_data(&self) -> Vec<u8> {
-        self.data.to_vec()
+        self.data.clone()
     }
 
     /// Decode and return the TLP type from the DW0 header fields.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub enum TlpMode {
     NonFlit,
 
     /// Flit-mode TLP framing (PCIe 6.0+).
-    /// Not yet implemented — returns `Err(TlpError::NotImplemented)`.
+    /// Supported by `TlpPacket::new` and `TlpPacket::get_flit_type()`.
+    /// `TlpPacketHeader::new` with this mode returns `Err(TlpError::NotImplemented)`.
     Flit,
 }
 
@@ -859,15 +860,15 @@ impl TryFrom<u8> for FlitTlpType {
 pub struct FlitDW0 {
     /// Decoded TLP type.
     pub tlp_type: FlitTlpType,
-    /// Traffic Class (bits [2:0] of byte 1).
+    /// Traffic Class (bits `[2:0]` of byte 1).
     pub tc: u8,
-    /// OHC presence bitmap (bits [4:0] of byte 1).
+    /// OHC presence bitmap (bits `[4:0]` of byte 1).
     /// Each set bit indicates one Optional Header Content word appended
     /// after the base header. Use [`FlitDW0::ohc_count`] for the DW count.
     pub ohc: u8,
-    /// Transaction Steering (bits [7:5] of byte 2).
+    /// Transaction Steering (bits `[7:5]` of byte 2).
     pub ts: u8,
-    /// Attributes (bits [4:2] of byte 2).
+    /// Attributes (bits `[4:2]` of byte 2).
     pub attr: u8,
     /// Payload length in DW. A value of `0` encodes 1024 DW.
     pub length: u16,
@@ -929,9 +930,9 @@ impl FlitDW0 {
 pub struct FlitOhcA {
     /// 20-bit PASID value extracted from bytes 0–2.
     pub pasid: u32,
-    /// First DW byte enables (bits [3:0] of byte 3).
+    /// First DW byte enables (bits `[3:0]` of byte 3).
     pub fdwbe: u8,
-    /// Last DW byte enables (bits [7:4] of byte 3).
+    /// Last DW byte enables (bits `[7:4]` of byte 3).
     pub ldwbe: u8,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#![warn(missing_docs)]
+#![deny(unsafe_code)]
+
+//! Rust library for parsing PCI Express Transaction Layer Packets (TLPs).
+//!
+//! Supports both non-flit (PCIe 1.0–5.0) and flit-mode (PCIe 6.0+) framing.
+
 use std::fmt::{self, Display};
 
 use bitfield::bitfield;
@@ -14,7 +21,7 @@ pub enum TlpMode {
     NonFlit,
 
     /// Flit-mode TLP framing (PCIe 6.0+).
-    /// Supported by `TlpPacket::new` and `TlpPacket::get_flit_type()`.
+    /// Supported by `TlpPacket::new` and `TlpPacket::flit_type()`.
     /// `TlpPacketHeader::new` with this mode returns `Err(TlpError::NotImplemented)`.
     Flit,
 }
@@ -52,13 +59,19 @@ impl fmt::Display for TlpError {
 
 impl std::error::Error for TlpError {}
 
+/// TLP format field encoding — encodes header size and whether a data payload is present.
 #[repr(u8)]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TlpFmt {
+    /// 3 DW header, no data payload.
     NoDataHeader3DW     = 0b000,
+    /// 4 DW header, no data payload.
     NoDataHeader4DW     = 0b001,
+    /// 3 DW header with data payload.
     WithDataHeader3DW   = 0b010,
+    /// 4 DW header with data payload.
     WithDataHeader4DW   = 0b011,
+    /// TLP Prefix (not a request or completion).
     TlpPrefix           = 0b100,
 }
 
@@ -93,15 +106,20 @@ impl TryFrom<u32> for TlpFmt {
 /// Atomic operation discriminant
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum AtomicOp {
+    /// Fetch-and-Add atomic operation.
     FetchAdd,
+    /// Unconditional Swap atomic operation.
     Swap,
+    /// Compare-and-Swap atomic operation.
     CompareSwap,
 }
 
 /// Operand width — derived from TLP format: 3DW → 32-bit, 4DW → 64-bit
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum AtomicWidth {
+    /// 32-bit operand (3 DW header).
     W32,
+    /// 64-bit operand (4 DW header).
     W64,
 }
 
@@ -147,29 +165,51 @@ impl TryFrom<u32> for TlpFormatEncodingType {
     }
 }
 
+/// High-level TLP transaction type decoded from the DW0 Format and Type fields.
 #[derive(PartialEq)]
 #[derive(Debug)]
 pub enum TlpType {
+    /// 32-bit or 64-bit Memory Read Request.
     MemReadReq,
+    /// Locked Memory Read Request.
     MemReadLockReq,
+    /// 32-bit or 64-bit Memory Write Request.
     MemWriteReq,
+    /// I/O Read Request.
     IOReadReq,
+    /// I/O Write Request.
     IOWriteReq,
+    /// Configuration Type 0 Read Request.
     ConfType0ReadReq,
+    /// Configuration Type 0 Write Request.
     ConfType0WriteReq,
+    /// Configuration Type 1 Read Request.
     ConfType1ReadReq,
+    /// Configuration Type 1 Write Request.
     ConfType1WriteReq,
+    /// Message Request (no data).
     MsgReq,
+    /// Message Request with data payload.
     MsgReqData,
+    /// Completion without data.
     Cpl,
+    /// Completion with data.
     CplData,
+    /// Locked Completion without data.
     CplLocked,
+    /// Locked Completion with data.
     CplDataLocked,
+    /// Fetch-and-Add AtomicOp Request.
     FetchAddAtomicOpReq,
+    /// Unconditional Swap AtomicOp Request.
     SwapAtomicOpReq,
+    /// Compare-and-Swap AtomicOp Request.
     CompareSwapAtomicOpReq,
+    /// Deferrable Memory Write Request.
     DeferrableMemWriteReq,
+    /// Local TLP Prefix.
     LocalTlpPrefix,
+    /// End-to-End TLP Prefix.
     EndToEndTlpPrefix,
 }
 
@@ -384,31 +424,48 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
 /// Both 3DW (32-bit) and 4DW (64-bit) headers implement this trait
 /// 3DW header is also used for all Legacy IO Requests.
 pub trait MemRequest {
+    /// Returns the Requester ID field (Bus/Device/Function).
     fn address(&self) -> u64;
+    /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
+    /// Returns the Last DW Byte Enable nibble.
     fn ldwbe(&self) -> u8;
+    /// Returns the First DW Byte Enable nibble.
     fn fdwbe(&self) -> u8;
 }
 
+/// Bitfield structure for both 3DW Memory Request and Legacy IO Request headers.
 // Structure for both 3DW Memory Request as well as Legacy IO Request
 bitfield! {
     pub struct MemRequest3DW(MSB0 [u8]);
     u32;
+    /// Returns the Requester ID field.
     pub get_requester_id,   _: 15, 0;
+    /// Returns the Tag field.
     pub get_tag,            _: 23, 16;
+    /// Returns the Last DW Byte Enable nibble.
     pub get_last_dw_be,     _: 27, 24;
+    /// Returns the First DW Byte Enable nibble.
     pub get_first_dw_be,    _: 31, 28;
+    /// Returns the 32-bit address field.
     pub get_address32,      _: 63, 32;
 }
 
+/// Bitfield structure for 4DW Memory Request headers.
 bitfield! {
     pub struct MemRequest4DW(MSB0 [u8]);
     u64;
+    /// Returns the Requester ID field.
     pub get_requester_id,   _: 15, 0;
+    /// Returns the Tag field.
     pub get_tag,            _: 23, 16;
+    /// Returns the Last DW Byte Enable nibble.
     pub get_last_dw_be,     _: 27, 24;
+    /// Returns the First DW Byte Enable nibble.
     pub get_first_dw_be,    _: 31, 28;
+    /// Returns the 64-bit address field.
     pub get_address64,      _: 95, 32;
 }
 
@@ -469,9 +526,9 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// fn decode(bytes: Vec<u8>) -> Result<(), TlpError> {
 ///     let tlp = TlpPacket::new(bytes, TlpMode::NonFlit)?;
 ///
-///     let tlpfmt = tlp.get_tlp_format()?;
+///     let tlpfmt = tlp.tlp_format()?;
 ///     // MemRequest contains only fields specific to PCI Memory Requests
-///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.get_data(), &tlpfmt)?;
+///     let mem_req: Box<dyn MemRequest> = new_mem_req(tlp.data(), &tlpfmt)?;
 ///
 ///     // Address is 64 bits regardless of TLP format
 ///     // println!("Memory Request Address: {:x}", mem_req.address());
@@ -479,7 +536,7 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 ///     // Format of TLP (3DW vs 4DW) is stored in the TLP header
 ///     println!("This TLP size is: {}", tlpfmt);
 ///     // Type LegacyIO vs MemRead vs MemWrite is stored in first DW of TLP
-///     println!("This TLP type is: {:?}", tlp.get_tlp_type());
+///     println!("This TLP type is: {:?}", tlp.tlp_type());
 ///     Ok(())
 /// }
 ///
@@ -502,12 +559,19 @@ pub fn new_mem_req(bytes: impl Into<Vec<u8>>, format: &TlpFmt) -> Result<Box<dyn
 /// Configuration Requests Headers are always same size (3DW),
 /// this trait is provided to have same API as other headers with variable size
 pub trait ConfigurationRequest {
+    /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
+    /// Returns the Bus Number.
     fn bus_nr(&self) -> u8;
+    /// Returns the Device Number.
     fn dev_nr(&self) -> u8;
+    /// Returns the Function Number.
     fn func_nr(&self) -> u8;
+    /// Returns the Extended Register Number.
     fn ext_reg_nr(&self) -> u8;
+    /// Returns the Register Number.
     fn reg_nr(&self) -> u8;
 }
 
@@ -534,25 +598,37 @@ pub trait ConfigurationRequest {
 /// let tlp = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
 /// // data() returns DW1+DW2 (8 bytes) — exactly what ConfigRequest needs
-/// let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.data().to_vec());
+/// // data() returns &[u8] — pass it directly, no .to_vec() needed
+/// let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.data());
 /// assert_eq!(config_req.bus_nr(), 0xC2);
 /// ```
-pub fn new_conf_req(bytes: Vec<u8>) -> Box<dyn ConfigurationRequest> {
-	Box::new(ConfigRequest(bytes))
+pub fn new_conf_req(bytes: impl Into<Vec<u8>>) -> Box<dyn ConfigurationRequest> {
+	Box::new(ConfigRequest(bytes.into()))
 }
 
+/// Bitfield structure for Configuration Request headers (DW1+DW2).
 bitfield! {
     pub struct ConfigRequest(MSB0 [u8]);
     u32;
+    /// Returns the Requester ID field.
     pub get_requester_id,   _: 15, 0;
+    /// Returns the Tag field.
     pub get_tag,            _: 23, 16;
+    /// Returns the Last DW Byte Enable nibble.
     pub get_last_dw_be,     _: 27, 24;
+    /// Returns the First DW Byte Enable nibble.
     pub get_first_dw_be,    _: 31, 28;
+    /// Returns the Bus Number field.
     pub get_bus_nr,         _: 39, 32;
+    /// Returns the Device Number field.
     pub get_dev_nr,         _: 44, 40;
+    /// Returns the Function Number field.
     pub get_func_nr,        _: 47, 45;
+    /// Reserved field.
     pub rsvd,               _: 51, 48;
+    /// Returns the Extended Register Number field.
     pub get_ext_reg_nr,     _: 55, 52;
+    /// Returns the Register Number field.
     pub get_register_nr,    _: 61, 56;
     r,                      _: 63, 62;
 }
@@ -587,25 +663,40 @@ impl <T: AsRef<[u8]>> ConfigurationRequest for ConfigRequest<T> {
 /// To obtain this trait `new_cmpl_req()` function has to be used
 /// Trait release user from dealing with bitfield structures.
 pub trait CompletionRequest {
+    /// Returns the 16-bit Completer ID.
     fn cmpl_id(&self) -> u16;
+    /// Returns the 3-bit Completion Status field.
     fn cmpl_stat(&self) -> u8;
+    /// Returns the BCM (Byte Count Modified) bit.
     fn bcm(&self) -> u8;
+    /// Returns the 12-bit Byte Count field.
     fn byte_cnt(&self) -> u16;
+    /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
+    /// Returns the 7-bit Lower Address field.
     fn laddr(&self) -> u8;
 }
 
+/// Bitfield structure for Completion Request DW2+DW3 fields.
 bitfield! {
     pub struct CompletionReqDW23(MSB0 [u8]);
     u16;
+    /// Returns the Completer ID field.
     pub get_completer_id,   _: 15, 0;
+    /// Returns the Completion Status field.
     pub get_cmpl_stat,      _: 18, 16;
+    /// Returns the BCM bit.
     pub get_bcm,            _: 19, 19;
+    /// Returns the Byte Count field.
     pub get_byte_cnt,       _: 31, 20;
+    /// Returns the Requester ID field.
     pub get_req_id,         _: 47, 32;
+    /// Returns the Tag field.
     pub get_tag,            _: 55, 48;
     r,                      _: 56, 56;
+    /// Returns the Lower Address field.
     pub get_laddr,          _: 63, 57;
 }
 
@@ -650,28 +741,38 @@ impl <T: AsRef<[u8]>> CompletionRequest for CompletionReqDW23<T> {
 ///
 /// println!("Requester ID from Completion{}", cmpl_req.req_id());
 /// ```
-pub fn new_cmpl_req(bytes: Vec<u8>) -> Box<dyn CompletionRequest> {
-	Box::new(CompletionReqDW23(bytes))
+pub fn new_cmpl_req(bytes: impl Into<Vec<u8>>) -> Box<dyn CompletionRequest> {
+	Box::new(CompletionReqDW23(bytes.into()))
 }
 
 /// Message Request trait
 /// Provide method to access fields in DW2-4 header is handled by TlpHeader
 pub trait MessageRequest {
+    /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
+    /// Returns the 8-bit Message Code field.
 	fn msg_code(&self) -> u8;
-	/// DW3-4 vary with Message Code Field
+    /// DW3 content — interpretation varies with Message Code.
     fn dw3(&self) -> u32;
+    /// DW4 content — interpretation varies with Message Code.
     fn dw4(&self) -> u32;
 }
 
+/// Bitfield structure for Message Request DW2–DW4 fields.
 bitfield! {
     pub struct MessageReqDW24(MSB0 [u8]);
     u32;
+    /// Returns the Requester ID field.
     pub get_requester_id,   _: 15, 0;
+    /// Returns the Tag field.
     pub get_tag,            _: 23, 16;
+    /// Returns the Message Code field.
     pub get_msg_code,       _: 31, 24;
+    /// Returns DW3 content.
     pub get_dw3,            _: 63, 32;
+    /// Returns DW4 content.
     pub get_dw4,            _: 95, 64;
 }
 
@@ -710,17 +811,22 @@ impl <T: AsRef<[u8]>> MessageRequest for MessageReqDW24<T> {
 ///
 /// println!("Requester ID from Message{}", msg_req.req_id());
 /// ```
-pub fn new_msg_req(bytes: Vec<u8>) -> Box<dyn MessageRequest> {
-	Box::new(MessageReqDW24(bytes))
+pub fn new_msg_req(bytes: impl Into<Vec<u8>>) -> Box<dyn MessageRequest> {
+	Box::new(MessageReqDW24(bytes.into()))
 }
 
 /// Atomic Request trait: header fields and operand(s) for atomic op TLPs.
 /// Use `new_atomic_req()` to obtain a trait object from raw packet bytes.
 pub trait AtomicRequest: std::fmt::Debug {
+    /// Returns the atomic operation type.
     fn op(&self) -> AtomicOp;
+    /// Returns the operand width (32-bit or 64-bit).
     fn width(&self) -> AtomicWidth;
+    /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
+    /// Returns the target address.
     fn address(&self) -> u64;
     /// Primary operand: addend (FetchAdd), new value (Swap), compare value (CAS)
     fn operand0(&self) -> u64;
@@ -789,8 +895,8 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 /// assert!(ar.operand1().is_none());
 /// ```
 pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpError> {
-    let tlp_type = pkt.get_tlp_type()?;
-    let format   = pkt.get_tlp_format()?;
+    let tlp_type = pkt.tlp_type()?;
+    let format   = pkt.tlp_format()?;
     let bytes    = pkt.data();
 
     let op = match tlp_type {
@@ -1153,6 +1259,26 @@ pub struct TlpPacketHeader {
     header: TlpHeader<Vec<u8>>,
 }
 
+impl fmt::Debug for TlpPacketHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlpPacketHeader")
+            .field("format",  &self.header.get_format())
+            .field("type",    &self.header.get_type())
+            .field("tc",      &self.header.get_tc())
+            .field("t9",      &self.header.get_t9())
+            .field("t8",      &self.header.get_t8())
+            .field("attr_b2", &self.header.get_attr_b2())
+            .field("ln",      &self.header.get_ln())
+            .field("th",      &self.header.get_th())
+            .field("td",      &self.header.get_td())
+            .field("ep",      &self.header.get_ep())
+            .field("attr",    &self.header.get_attr())
+            .field("at",      &self.header.get_at())
+            .field("length",  &self.header.get_length())
+            .finish()
+    }
+}
+
 impl TlpPacketHeader {
     /// Create a new `TlpPacketHeader` from raw bytes and the specified framing mode.
     ///
@@ -1189,25 +1315,36 @@ impl TlpPacketHeader {
     /// - [`TlpError::InvalidType`] if the 5-bit Type field is not a known value.
     /// - [`TlpError::UnsupportedCombination`] if Fmt and Type are individually valid
     ///   but not a legal pair (e.g. IO Request with 4DW header).
-    pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
+    pub fn tlp_type(&self) -> Result<TlpType, TlpError> {
         self.header.get_tlp_type()
     }
 
-    /// Raw 3-bit Format field from DW0 (`bits[2:0]` of byte 0 in MSB0 layout).
-    pub fn get_format(&self) -> u32 {self.header.get_format()}
-    pub fn get_type(&self) -> u32 {self.header.get_type()}
-    pub fn get_t9(&self) -> u32 {self.header.get_t9()}
-    pub fn get_tc(&self) -> u32 {self.header.get_tc()}
-    pub fn get_t8(&self) -> u32 {self.header.get_t8()}
-    pub fn get_attr_b2(&self) -> u32 {self.header.get_attr_b2()}
-    pub fn get_ln(&self) -> u32 {self.header.get_ln()}
-    pub fn get_th(&self) -> u32 {self.header.get_th()}
-    pub fn get_td(&self) -> u32 {self.header.get_td()}
-    pub fn get_ep(&self) -> u32 {self.header.get_ep()}
-    pub fn get_attr(&self) -> u32 {self.header.get_attr()}
-    pub fn get_at(&self) -> u32 {self.header.get_at()}
-    pub fn get_length(&self) -> u32 {self.header.get_length()}
+    /// Decode and return the TLP type from the DW0 header fields.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacketHeader::tlp_type`] which follows Rust naming conventions.
+    #[deprecated(since = "0.5.0", note = "use tlp_type() instead")]
+    pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
+        self.tlp_type()
+    }
 
+    /// Raw Traffic Class field from DW0 (`bits[11:9]`).
+    pub fn get_tc(&self) -> u32 { self.header.get_tc() }
+
+    /// Raw 3-bit Format field from DW0 (`bits[2:0]` of byte 0 in MSB0 layout).
+    pub(crate) fn get_format(&self) -> u32 {self.header.get_format()}
+    pub(crate) fn get_type(&self) -> u32 {self.header.get_type()}
+    pub(crate) fn get_t9(&self) -> u32 {self.header.get_t9()}
+    pub(crate) fn get_t8(&self) -> u32 {self.header.get_t8()}
+    pub(crate) fn get_attr_b2(&self) -> u32 {self.header.get_attr_b2()}
+    pub(crate) fn get_ln(&self) -> u32 {self.header.get_ln()}
+    pub(crate) fn get_th(&self) -> u32 {self.header.get_th()}
+    pub(crate) fn get_td(&self) -> u32 {self.header.get_td()}
+    pub(crate) fn get_ep(&self) -> u32 {self.header.get_ep()}
+    pub(crate) fn get_attr(&self) -> u32 {self.header.get_attr()}
+    pub(crate) fn get_at(&self) -> u32 {self.header.get_at()}
+    pub(crate) fn get_length(&self) -> u32 {self.header.get_length()}
 }
 
 /// TLP Packet structure is high level abstraction for entire TLP packet
@@ -1230,10 +1367,10 @@ impl TlpPacketHeader {
 /// let bytes = vec![0x00, 0x00, 0x20, 0x01, 0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
 /// let packet = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
-/// let header = packet.get_header();
+/// let header = packet.header();
 /// // TLP Type tells us what is this packet
-/// let tlp_type = header.get_tlp_type().unwrap();
-/// let tlp_format = packet.get_tlp_format().unwrap();
+/// let tlp_type = header.tlp_type().unwrap();
+/// let tlp_format = packet.tlp_format().unwrap();
 /// let requester_id;
 /// match (tlp_type) {
 ///      TlpType::MemReadReq |
@@ -1244,17 +1381,17 @@ impl TlpPacketHeader {
 ///      TlpType::IOWriteReq |
 ///      TlpType::FetchAddAtomicOpReq |
 ///      TlpType::SwapAtomicOpReq |
-///      TlpType::CompareSwapAtomicOpReq => requester_id = new_mem_req(packet.get_data(), &tlp_format).unwrap().req_id(),
+///      TlpType::CompareSwapAtomicOpReq => requester_id = new_mem_req(packet.data(), &tlp_format).unwrap().req_id(),
 ///      TlpType::ConfType0ReadReq |
 ///      TlpType::ConfType0WriteReq |
 ///      TlpType::ConfType1ReadReq |
-///      TlpType::ConfType1WriteReq => requester_id = new_conf_req(packet.get_data()).req_id(),
+///      TlpType::ConfType1WriteReq => requester_id = new_conf_req(packet.data().to_vec()).req_id(),
 ///      TlpType::MsgReq |
-///      TlpType::MsgReqData => requester_id = new_msg_req(packet.get_data()).req_id(),
+///      TlpType::MsgReqData => requester_id = new_msg_req(packet.data().to_vec()).req_id(),
 ///      TlpType::Cpl |
 ///      TlpType::CplData |
 ///      TlpType::CplLocked |
-///      TlpType::CplDataLocked => requester_id = new_cmpl_req(packet.get_data()).req_id(),
+///      TlpType::CplDataLocked => requester_id = new_cmpl_req(packet.data().to_vec()).req_id(),
 ///      TlpType::LocalTlpPrefix |
 ///      TlpType::EndToEndTlpPrefix => println!("I need to implement TLP Type: {:?}", tlp_type),
 /// }
@@ -1265,6 +1402,16 @@ pub struct TlpPacket {
     /// `None` for non-flit packets.
     flit_dw0: Option<FlitDW0>,
     data: Vec<u8>,
+}
+
+impl fmt::Debug for TlpPacket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlpPacket")
+            .field("header",   &self.header)
+            .field("flit_dw0", &self.flit_dw0)
+            .field("data_len", &self.data.len())
+            .finish()
+    }
 }
 
 impl TlpPacket {
@@ -1314,16 +1461,21 @@ impl TlpPacket {
         }
         let payload = bytes[hdr_bytes..].to_vec();
 
-        // Use a dummy non-flit header; callers should use get_flit_type() for type queries.
+        // Use a dummy non-flit header; callers should use flit_type() for type queries.
         let dummy = TlpPacketHeader::new_non_flit(vec![0u8; 4])?;
         Ok(TlpPacket { header: dummy, flit_dw0: Some(dw0), data: payload })
     }
 
+    // -----------------------------------------------------------------------
+    // Preferred (non-get_*) API
+    // -----------------------------------------------------------------------
+
     /// Returns a reference to the DW0 packet header.
     ///
-    /// For flit-mode packets the header fields reflect the dummy all-zero
-    /// placeholder; use [`TlpPacket::get_flit_type`] instead.
-    pub fn get_header(&self) -> &TlpPacketHeader {
+    /// For flit-mode packets the underlying `TlpPacketHeader` holds an all-zero
+    /// placeholder and its fields are **meaningless**.  Check [`TlpPacket::mode`]
+    /// first and use [`TlpPacket::flit_type`] for flit-mode packets.
+    pub fn header(&self) -> &TlpPacketHeader {
         &self.header
     }
 
@@ -1334,19 +1486,9 @@ impl TlpPacket {
         &self.data
     }
 
-    /// Returns the packet payload bytes as an owned `Vec<u8>`.
-    ///
-    /// # Deprecation
-    ///
-    /// Prefer [`TlpPacket::data`] which returns `&[u8]` without allocating.
-    #[deprecated(since = "0.6.0", note = "use data() which returns &[u8] instead")]
-    pub fn get_data(&self) -> Vec<u8> {
-        self.data.clone()
-    }
-
     /// Decode and return the TLP type from the DW0 header fields.
     ///
-    /// For flit-mode packets, use [`TlpPacket::get_flit_type`] instead.
+    /// For flit-mode packets, use [`TlpPacket::flit_type`] instead.
     ///
     /// # Errors
     ///
@@ -1354,22 +1496,22 @@ impl TlpPacket {
     /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is unknown.
     /// - [`TlpError::InvalidType`] if the 5-bit Type field is unknown.
     /// - [`TlpError::UnsupportedCombination`] if the Fmt/Type pair is not legal.
-    pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
+    pub fn tlp_type(&self) -> Result<TlpType, TlpError> {
         if self.flit_dw0.is_some() {
             return Err(TlpError::NotImplemented);
         }
-        self.header.get_tlp_type()
+        self.header.tlp_type()
     }
 
     /// Decode and return the TLP format (3DW/4DW, with/without data) from DW0.
     ///
-    /// For flit-mode packets, use [`TlpPacket::get_flit_type`] instead.
+    /// For flit-mode packets, use [`TlpPacket::flit_type`] instead.
     ///
     /// # Errors
     ///
     /// - [`TlpError::NotImplemented`] if this packet was created with `TlpMode::Flit`.
     /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is not a known value.
-    pub fn get_tlp_format(&self) -> Result<TlpFmt, TlpError> {
+    pub fn tlp_format(&self) -> Result<TlpFmt, TlpError> {
         if self.flit_dw0.is_some() {
             return Err(TlpError::NotImplemented);
         }
@@ -1378,8 +1520,84 @@ impl TlpPacket {
 
     /// Returns the flit-mode TLP type when the packet was created from
     /// `TlpMode::Flit` bytes, or `None` for non-flit packets.
-    pub fn get_flit_type(&self) -> Option<FlitTlpType> {
+    pub fn flit_type(&self) -> Option<FlitTlpType> {
         self.flit_dw0.map(|d| d.tlp_type)
+    }
+
+    /// Returns the framing mode this packet was created with.
+    ///
+    /// Use this to dispatch cleanly between the flit-mode and non-flit-mode
+    /// method sets.  Relying on `flit_type().is_some()` as an indirect proxy
+    /// works but obscures intent; `mode()` makes the check self-documenting:
+    ///
+    /// ```
+    /// use rtlp_lib::{TlpPacket, TlpMode};
+    ///
+    /// # let bytes = vec![0x00u8; 4];
+    /// let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
+    /// match pkt.mode() {
+    ///     TlpMode::Flit    => { /* use pkt.flit_type() */ }
+    ///     TlpMode::NonFlit => { /* use pkt.tlp_type(), pkt.tlp_format() */ }
+    ///     // TlpMode is #[non_exhaustive] — wildcard required in external code
+    ///     _ => {}
+    /// }
+    /// ```
+    pub fn mode(&self) -> TlpMode {
+        if self.flit_dw0.is_some() { TlpMode::Flit } else { TlpMode::NonFlit }
+    }
+
+    // -----------------------------------------------------------------------
+    // Deprecated aliases — kept for backward compatibility
+    // -----------------------------------------------------------------------
+
+    /// Returns a reference to the DW0 packet header.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::header`] which follows Rust naming conventions.
+    #[deprecated(since = "0.5.0", note = "use header() instead")]
+    pub fn get_header(&self) -> &TlpPacketHeader {
+        self.header()
+    }
+
+    /// Returns the packet payload bytes as an owned `Vec<u8>`.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::data`] which returns `&[u8]` without allocating.
+    #[deprecated(since = "0.5.0", note = "use data() which returns &[u8] instead")]
+    pub fn get_data(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+
+    /// Decode and return the TLP type from the DW0 header fields.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::tlp_type`] which follows Rust naming conventions.
+    #[deprecated(since = "0.5.0", note = "use tlp_type() instead")]
+    pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
+        self.tlp_type()
+    }
+
+    /// Decode and return the TLP format from DW0.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::tlp_format`] which follows Rust naming conventions.
+    #[deprecated(since = "0.5.0", note = "use tlp_format() instead")]
+    pub fn get_tlp_format(&self) -> Result<TlpFmt, TlpError> {
+        self.tlp_format()
+    }
+
+    /// Returns the flit-mode TLP type.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer [`TlpPacket::flit_type`] which follows Rust naming conventions.
+    #[deprecated(since = "0.5.0", note = "use flit_type() instead")]
+    pub fn get_flit_type(&self) -> Option<FlitTlpType> {
+        self.flit_type()
     }
 }
 
@@ -1548,7 +1766,7 @@ mod tests {
         // NOP flit TLP (type 0x00, 1 DW base header, no payload)
         let bytes = vec![0x00, 0x00, 0x00, 0x00];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+        assert_eq!(pkt.flit_type(), Some(FlitTlpType::Nop));
         assert!(pkt.data().is_empty());
     }
 
@@ -1557,7 +1775,7 @@ mod tests {
         // MRd32 flit (type 0x03, 3 DW base header, no payload despite Length=1)
         let bytes = vec![0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+        assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemRead32));
         assert!(pkt.data().is_empty()); // read request, no payload
     }
 
@@ -1571,15 +1789,15 @@ mod tests {
             0xDE, 0xAD, 0xBE, 0xEF, // payload
         ];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
+        assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemWrite32));
         assert_eq!(pkt.data(), [0xDE, 0xAD, 0xBE, 0xEF]);
     }
 
     #[test]
     fn packet_new_flit_nonflit_returns_none_for_flit_type() {
-        // Non-flit packets should return None from get_flit_type()
+        // Non-flit packets should return None from flit_type()
         let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.get_flit_type(), None);
+        assert_eq!(pkt.flit_type(), None);
     }
 
     #[test]
@@ -1823,10 +2041,10 @@ mod tests {
             0xDE, 0xAD, 0x00, 0x00, // address32=0xDEAD0000
         ];
         let pkt = TlpPacket::new(mk_tlp(0b010, 0b11011, &payload), TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
-        assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+        assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
-        let mr = new_mem_req(pkt.data().to_vec(), &pkt.get_tlp_format().unwrap()).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &pkt.tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xABCD);
         assert_eq!(mr.tag(),    0x42);
         assert_eq!(mr.address(), 0xDEAD_0000);
@@ -1841,10 +2059,10 @@ mod tests {
             0x55, 0x66, 0x77, 0x88, // address64 lo
         ];
         let pkt = TlpPacket::new(mk_tlp(0b011, 0b11011, &payload), TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
-        assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+        assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
-        let mr = new_mem_req(pkt.data().to_vec(), &pkt.get_tlp_format().unwrap()).unwrap();
+        let mr = new_mem_req(pkt.data().to_vec(), &pkt.tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xBEEF);
         assert_eq!(mr.tag(),    0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);
@@ -1939,10 +2157,10 @@ mod tests {
 
         let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload), TlpMode::NonFlit).unwrap();
 
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
-        assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
+        assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
-        let fmt = pkt.get_tlp_format().unwrap();
+        let fmt = pkt.tlp_format().unwrap();
         let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0x1234);
         assert_eq!(mr.tag(),     0x56);
@@ -1968,10 +2186,10 @@ mod tests {
 
         let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload), TlpMode::NonFlit).unwrap();
 
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
-        assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
+        assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
-        let fmt = pkt.get_tlp_format().unwrap();
+        let fmt = pkt.tlp_format().unwrap();
         let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
         assert_eq!(mr.req_id(),  0xBEEF);
         assert_eq!(mr.tag(),     0xA5);
@@ -2316,5 +2534,40 @@ mod tests {
         assert_eq!(msg.dw3(),      0x1234_5678);
         assert_eq!(msg.dw4(),      0x9ABC_DEF0);
     }
-}
 
+    // ── Debug impls ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn tlp_packet_header_debug() {
+        let hdr = TlpPacketHeader::new(vec![0x00, 0x00, 0x20, 0x01], TlpMode::NonFlit).unwrap();
+        let s = format!("{:?}", hdr);
+        assert!(s.contains("TlpPacketHeader"));
+        assert!(s.contains("format"));
+        assert!(s.contains("length"));
+    }
+
+    #[test]
+    fn tlp_packet_debug() {
+        let pkt = TlpPacket::new(vec![0x40, 0x00, 0x00, 0x01, 0xDE, 0xAD], TlpMode::NonFlit).unwrap();
+        let s = format!("{:?}", pkt);
+        assert!(s.contains("TlpPacket"));
+        assert!(s.contains("data_len"));
+    }
+
+    #[test]
+    fn packet_mode_returns_correct_mode() {
+        let non_flit = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(non_flit.mode(), TlpMode::NonFlit);
+
+        let flit = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
+        assert_eq!(flit.mode(), TlpMode::Flit);
+    }
+
+    #[test]
+    fn tlp_packet_debug_flit() {
+        let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
+        let s = format!("{:?}", pkt);
+        assert!(s.contains("TlpPacket"));
+        assert!(s.contains("flit_dw0"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1254,21 +1254,33 @@ impl TlpPacket {
 
     /// Decode and return the TLP type from the DW0 header fields.
     ///
+    /// For flit-mode packets, use [`TlpPacket::get_flit_type`] instead.
+    ///
     /// # Errors
     ///
+    /// - [`TlpError::NotImplemented`] if this packet was created with `TlpMode::Flit`.
     /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is unknown.
     /// - [`TlpError::InvalidType`] if the 5-bit Type field is unknown.
     /// - [`TlpError::UnsupportedCombination`] if the Fmt/Type pair is not legal.
     pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
+        if self.flit_dw0.is_some() {
+            return Err(TlpError::NotImplemented);
+        }
         self.header.get_tlp_type()
     }
 
     /// Decode and return the TLP format (3DW/4DW, with/without data) from DW0.
     ///
+    /// For flit-mode packets, use [`TlpPacket::get_flit_type`] instead.
+    ///
     /// # Errors
     ///
+    /// - [`TlpError::NotImplemented`] if this packet was created with `TlpMode::Flit`.
     /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is not a known value.
     pub fn get_tlp_format(&self) -> Result<TlpFmt, TlpError> {
+        if self.flit_dw0.is_some() {
+            return Err(TlpError::NotImplemented);
+        }
         TlpFmt::try_from(self.header.get_format())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,6 +973,61 @@ impl FlitDW0 {
     }
 }
 
+/// Iterator over a packed stream of flit-mode TLPs.
+///
+/// Walks a byte slice containing back-to-back flit TLPs and yields
+/// `Ok((offset, FlitTlpType, total_size))` for each one.
+///
+/// Returns `Some(Err(TlpError::InvalidLength))` if a TLP extends beyond
+/// the end of the slice (truncated payload). After the first error,
+/// subsequent calls to `next()` return `None`.
+///
+/// # Examples
+///
+/// ```
+/// use rtlp_lib::{FlitStreamWalker, FlitTlpType};
+///
+/// let nop = [0x00u8, 0x00, 0x00, 0x00];
+/// let (offset, typ, size) = FlitStreamWalker::new(&nop).next().unwrap().unwrap();
+/// assert_eq!(offset, 0);
+/// assert_eq!(typ, FlitTlpType::Nop);
+/// assert_eq!(size, 4);
+/// ```
+pub struct FlitStreamWalker<'a> {
+    data: &'a [u8],
+    pos: usize,
+    errored: bool,
+}
+
+impl<'a> FlitStreamWalker<'a> {
+    /// Create a new walker over a packed flit TLP byte stream.
+    pub fn new(data: &'a [u8]) -> Self {
+        FlitStreamWalker { data, pos: 0, errored: false }
+    }
+}
+
+impl<'a> Iterator for FlitStreamWalker<'a> {
+    type Item = Result<(usize, FlitTlpType, usize), TlpError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.errored || self.pos >= self.data.len() {
+            return None;
+        }
+        let offset = self.pos;
+        let dw0 = match FlitDW0::from_dw0(&self.data[self.pos..]) {
+            Ok(d)  => d,
+            Err(e) => { self.errored = true; return Some(Err(e)); }
+        };
+        let total = dw0.total_bytes();
+        if self.pos + total > self.data.len() {
+            self.errored = true;
+            return Some(Err(TlpError::InvalidLength));
+        }
+        self.pos += total;
+        Some(Ok((offset, dw0.tlp_type, total)))
+    }
+}
+
 // ============================================================================
 // End of Flit Mode types
 // ============================================================================
@@ -1077,21 +1132,21 @@ impl TlpPacketHeader {
 /// ```
 pub struct TlpPacket {
     header: TlpPacketHeader,
+    /// Set when the packet was created from `TlpMode::Flit` bytes.
+    /// `None` for non-flit packets.
+    flit_dw0: Option<FlitDW0>,
     data: Vec<u8>,
 }
 
 impl TlpPacket {
     /// Create a new `TlpPacket` from raw bytes and the specified framing mode.
     ///
-    /// Use `TlpMode::NonFlit` for standard PCIe 1.0–5.0 TLP framing where bytes
-    /// are interpreted directly as a TLP header followed by an optional payload.
-    ///
-    /// `TlpMode::Flit` is reserved for future PCIe 6.0 flit-mode support and
-    /// currently returns `Err(TlpError::NotImplemented)`.
+    /// Use `TlpMode::NonFlit` for standard PCIe 1.0–5.0 TLP framing.
+    /// Use `TlpMode::Flit` for PCIe 6.x flit-mode TLP framing.
     pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacket, TlpError> {
         match mode {
             TlpMode::NonFlit => Self::new_non_flit(bytes),
-            TlpMode::Flit => Err(TlpError::NotImplemented),
+            TlpMode::Flit    => Self::new_flit(bytes),
         }
     }
 
@@ -1105,8 +1160,28 @@ impl TlpPacket {
         let data = ownbytes.drain(4..).collect();
         Ok(TlpPacket {
             header: TlpPacketHeader::new_non_flit(header)?,
+            flit_dw0: None,
             data,
         })
+    }
+
+    fn new_flit(bytes: Vec<u8>) -> Result<TlpPacket, TlpError> {
+        if bytes.len() < 4 {
+            return Err(TlpError::InvalidLength);
+        }
+        let dw0 = FlitDW0::from_dw0(&bytes)?;
+        dw0.validate_mandatory_ohc()?;
+
+        let hdr_bytes = (dw0.tlp_type.base_header_dw() as usize
+            + dw0.ohc_count() as usize) * 4;
+        if bytes.len() < hdr_bytes {
+            return Err(TlpError::InvalidLength);
+        }
+        let payload = bytes[hdr_bytes..].to_vec();
+
+        // Use a dummy non-flit header; callers should use get_flit_type() for type queries.
+        let dummy = TlpPacketHeader::new_non_flit(vec![0u8; 4])?;
+        Ok(TlpPacket { header: dummy, flit_dw0: Some(dw0), data: payload })
     }
 
     pub fn get_header(&self) -> &TlpPacketHeader {
@@ -1123,6 +1198,12 @@ impl TlpPacket {
 
     pub fn get_tlp_format(&self) -> Result<TlpFmt, TlpError> {
         TlpFmt::try_from(self.header.get_format())
+    }
+
+    /// Returns the flit-mode TLP type when the packet was created from
+    /// `TlpMode::Flit` bytes, or `None` for non-flit packets.
+    pub fn get_flit_type(&self) -> Option<FlitTlpType> {
+        self.flit_dw0.map(|d| d.tlp_type)
     }
 }
 
@@ -1276,16 +1357,50 @@ mod tests {
         assert!(matches!(TlpPacketHeader::new(vec![0x00, 0x00], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
     }
 
-    // ── TlpMode: Flit returns NotImplemented ──────────────────────────────
+    // ── TlpMode: Flit ─────────────────────────────────────────────────────
 
     #[test]
-    fn packet_new_flit_returns_not_implemented() {
-        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-        assert_eq!(TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+    fn packet_new_flit_succeeds_for_valid_nop() {
+        // NOP flit TLP (type 0x00, 1 DW base header, no payload)
+        let bytes = vec![0x00, 0x00, 0x00, 0x00];
+        let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
+        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+        assert!(pkt.get_data().is_empty());
+    }
+
+    #[test]
+    fn packet_new_flit_mrd32_has_no_payload() {
+        // MRd32 flit (type 0x03, 3 DW base header, no payload despite Length=1)
+        let bytes = vec![0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
+        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+        assert!(pkt.get_data().is_empty()); // read request, no payload
+    }
+
+    #[test]
+    fn packet_new_flit_mwr32_has_payload() {
+        // MWr32 flit (type 0x40, 3 DW base header + 1 DW payload)
+        let bytes = vec![
+            0x40, 0x00, 0x00, 0x01, // DW0: MemWrite32, length=1
+            0x00, 0x00, 0x00, 0x00, // DW1
+            0x00, 0x00, 0x00, 0x00, // DW2
+            0xDE, 0xAD, 0xBE, 0xEF, // payload
+        ];
+        let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
+        assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
+        assert_eq!(pkt.get_data(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn packet_new_flit_nonflit_returns_none_for_flit_type() {
+        // Non-flit packets should return None from get_flit_type()
+        let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(pkt.get_flit_type(), None);
     }
 
     #[test]
     fn packet_header_new_flit_returns_not_implemented() {
+        // TlpPacketHeader::new() with Flit still returns NotImplemented
         let bytes = vec![0x00, 0x00, 0x00, 0x00];
         assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,12 @@ impl TryFrom<u32> for TlpFmt {
 
     fn try_from(v: u32) -> Result<Self, Self::Error> {
         match v {
-            x if x == TlpFmt::NoDataHeader3DW as u32 => Ok(TlpFmt::NoDataHeader3DW),
-            x if x == TlpFmt::NoDataHeader4DW as u32 => Ok(TlpFmt::NoDataHeader4DW),
-            x if x == TlpFmt::WithDataHeader3DW as u32 => Ok(TlpFmt::WithDataHeader3DW),
-            x if x == TlpFmt::WithDataHeader4DW as u32 => Ok(TlpFmt::WithDataHeader4DW),
-            x if x == TlpFmt::TlpPrefix as u32 => Ok(TlpFmt::TlpPrefix),
-            _ => Err(TlpError::InvalidFormat),
+            0b000 => Ok(TlpFmt::NoDataHeader3DW),
+            0b001 => Ok(TlpFmt::NoDataHeader4DW),
+            0b010 => Ok(TlpFmt::WithDataHeader3DW),
+            0b011 => Ok(TlpFmt::WithDataHeader4DW),
+            0b100 => Ok(TlpFmt::TlpPrefix),
+            _     => Err(TlpError::InvalidFormat),
         }
     }
 }
@@ -125,18 +125,18 @@ impl TryFrom<u32> for TlpFormatEncodingType {
 
     fn try_from(v: u32) -> Result<Self, Self::Error> {
         match v {
-            x if x == TlpFormatEncodingType::MemoryRequest as u32 			=> Ok(TlpFormatEncodingType::MemoryRequest),
-            x if x == TlpFormatEncodingType::MemoryLockRequest as u32 		=> Ok(TlpFormatEncodingType::MemoryLockRequest),
-            x if x == TlpFormatEncodingType::IORequest as u32 				=> Ok(TlpFormatEncodingType::IORequest),
-            x if x == TlpFormatEncodingType::ConfigType0Request as u32 		=> Ok(TlpFormatEncodingType::ConfigType0Request),
-            x if x == TlpFormatEncodingType::ConfigType1Request as u32 		=> Ok(TlpFormatEncodingType::ConfigType1Request),
-            x if x == TlpFormatEncodingType::Completion as u32 				=> Ok(TlpFormatEncodingType::Completion),
-            x if x == TlpFormatEncodingType::CompletionLocked  as u32 		=> Ok(TlpFormatEncodingType::CompletionLocked),
-            x if x == TlpFormatEncodingType::FetchAtomicOpRequest as u32 	=> Ok(TlpFormatEncodingType::FetchAtomicOpRequest),
-            x if x == TlpFormatEncodingType::UnconSwapAtomicOpRequest as u32 => Ok(TlpFormatEncodingType::UnconSwapAtomicOpRequest),
-            x if x == TlpFormatEncodingType::CompSwapAtomicOpRequest as u32 => Ok(TlpFormatEncodingType::CompSwapAtomicOpRequest),
-            x if x == TlpFormatEncodingType::DeferrableMemoryWriteRequest as u32 => Ok(TlpFormatEncodingType::DeferrableMemoryWriteRequest),
-            _ => Err(TlpError::InvalidType),
+            0b00000 => Ok(TlpFormatEncodingType::MemoryRequest),
+            0b00001 => Ok(TlpFormatEncodingType::MemoryLockRequest),
+            0b00010 => Ok(TlpFormatEncodingType::IORequest),
+            0b00100 => Ok(TlpFormatEncodingType::ConfigType0Request),
+            0b00101 => Ok(TlpFormatEncodingType::ConfigType1Request),
+            0b01010 => Ok(TlpFormatEncodingType::Completion),
+            0b01011 => Ok(TlpFormatEncodingType::CompletionLocked),
+            0b01100 => Ok(TlpFormatEncodingType::FetchAtomicOpRequest),
+            0b01101 => Ok(TlpFormatEncodingType::UnconSwapAtomicOpRequest),
+            0b01110 => Ok(TlpFormatEncodingType::CompSwapAtomicOpRequest),
+            0b11011 => Ok(TlpFormatEncodingType::DeferrableMemoryWriteRequest),
+            _       => Err(TlpError::InvalidType),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -926,7 +926,6 @@ impl Display for FlitTlpType {
             FlitTlpType::UioMemWrite         => "UIO Memory Write (64-bit)",
             FlitTlpType::MsgDToRc            => "Message with Data routed to RC",
             FlitTlpType::LocalTlpPrefix      => "Local TLP Prefix",
-            _                                => "Unknown FlitTlpType",
         };
         write!(f, "{name}")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,22 @@ use std::fmt::Display;
 #[macro_use]
 extern crate bitfield;
 
+/// Selects the framing mode used to interpret the raw byte buffer.
+///
+/// Non-flit mode covers PCIe 1.0 through 5.0. Flit mode was introduced
+/// in PCIe 6.0 and uses fixed 256-byte containers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TlpMode {
+    /// Standard non-flit TLP framing (PCIe 1.0 – 5.0).
+    /// Bytes are interpreted directly as a TLP header followed by optional payload.
+    NonFlit,
+
+    /// Flit-mode TLP framing (PCIe 6.0+).
+    /// Not yet implemented — returns `Err(TlpError::NotImplemented)`.
+    Flit,
+}
+
 /// Errors that can occur when parsing TLP packets
 #[derive(Debug, Clone, PartialEq)]
 pub enum TlpError {
@@ -15,6 +31,8 @@ pub enum TlpError {
     UnsupportedCombination,
     /// Payload/header byte slice is too short to contain the expected fields
     InvalidLength,
+    /// Feature exists in the API but is not yet implemented
+    NotImplemented,
 }
 
 #[repr(u8)]
@@ -376,11 +394,12 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// use rtlp_lib::TlpPacket;
 /// use rtlp_lib::TlpFmt;
 /// use rtlp_lib::TlpError;
+/// use rtlp_lib::TlpMode;
 /// use rtlp_lib::MemRequest;
 /// use rtlp_lib::new_mem_req;
 ///
 /// fn decode(bytes: Vec<u8>) -> Result<(), TlpError> {
-///     let tlp = TlpPacket::new(bytes)?;
+///     let tlp = TlpPacket::new(bytes, TlpMode::NonFlit)?;
 ///
 ///     let tlpfmt = tlp.get_tlp_format()?;
 ///     // MemRequest contains only fields specific to PCI Memory Requests
@@ -432,11 +451,12 @@ pub trait ConfigurationRequest {
 ///
 /// use rtlp_lib::TlpPacket;
 /// use rtlp_lib::TlpFmt;
+/// use rtlp_lib::TlpMode;
 /// use rtlp_lib::ConfigurationRequest;
 /// use rtlp_lib::new_conf_req;
 ///
 /// let bytes = vec![0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/// let tlp = TlpPacket::new(bytes).unwrap();
+/// let tlp = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
 ///     let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.get_data(), &tlpfmt);
@@ -676,7 +696,7 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 /// # Examples
 ///
 /// ```
-/// use rtlp_lib::{TlpPacket, AtomicRequest, new_atomic_req};
+/// use rtlp_lib::{TlpPacket, TlpMode, AtomicRequest, new_atomic_req};
 ///
 /// // FetchAdd 3DW: DW0 byte0 = (fmt=0b010 << 5) | typ=0b01100 = 0x4C
 /// let bytes = vec![
@@ -685,7 +705,7 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 ///     0x00, 0x00, 0x10, 0x00, // DW2: address32=0x0000_1000
 ///     0x00, 0x00, 0x00, 0x04, // operand: addend=4
 /// ];
-/// let pkt = TlpPacket::new(bytes).unwrap();
+/// let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 /// let ar = new_atomic_req(&pkt).unwrap();
 /// assert_eq!(ar.req_id(),   0xABCD);
 /// assert_eq!(ar.operand0(), 4);
@@ -740,7 +760,19 @@ pub struct TlpPacketHeader {
 }
 
 impl TlpPacketHeader {
-    pub fn new(bytes: Vec<u8>) -> Result<TlpPacketHeader, TlpError> {
+    /// Create a new `TlpPacketHeader` from raw bytes and the specified framing mode.
+    ///
+    /// Use `TlpMode::NonFlit` for PCIe 1.0–5.0 standard TLP framing.
+    /// `TlpMode::Flit` is reserved for future PCIe 6.0 support and currently
+    /// returns `Err(TlpError::NotImplemented)`.
+    pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacketHeader, TlpError> {
+        match mode {
+            TlpMode::NonFlit => Self::new_non_flit(bytes),
+            TlpMode::Flit => Err(TlpError::NotImplemented),
+        }
+    }
+
+    fn new_non_flit(bytes: Vec<u8>) -> Result<TlpPacketHeader, TlpError> {
         if bytes.len() < 4 {
             return Err(TlpError::InvalidLength);
         }
@@ -779,6 +811,7 @@ impl TlpPacketHeader {
 /// use rtlp_lib::TlpPacket;
 /// use rtlp_lib::TlpFmt;
 /// use rtlp_lib::TlpType;
+/// use rtlp_lib::TlpMode;
 /// use rtlp_lib::new_msg_req;
 /// use rtlp_lib::new_conf_req;
 /// use rtlp_lib::new_mem_req;
@@ -787,7 +820,7 @@ impl TlpPacketHeader {
 /// // Bytes for full TLP Packet
 /// //               <------- DW1 -------->  <------- DW2 -------->  <------- DW3 -------->  <------- DW4 -------->
 /// let bytes = vec![0x00, 0x00, 0x20, 0x01, 0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
-/// let packet = TlpPacket::new(bytes).unwrap();
+/// let packet = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
 /// let header = packet.get_header();
 /// // TLP Type tells us what is this packet
@@ -824,7 +857,21 @@ pub struct TlpPacket {
 }
 
 impl TlpPacket {
-    pub fn new(bytes: Vec<u8>) -> Result<TlpPacket, TlpError> {
+    /// Create a new `TlpPacket` from raw bytes and the specified framing mode.
+    ///
+    /// Use `TlpMode::NonFlit` for standard PCIe 1.0–5.0 TLP framing where bytes
+    /// are interpreted directly as a TLP header followed by an optional payload.
+    ///
+    /// `TlpMode::Flit` is reserved for future PCIe 6.0 flit-mode support and
+    /// currently returns `Err(TlpError::NotImplemented)`.
+    pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacket, TlpError> {
+        match mode {
+            TlpMode::NonFlit => Self::new_non_flit(bytes),
+            TlpMode::Flit => Err(TlpError::NotImplemented),
+        }
+    }
+
+    fn new_non_flit(bytes: Vec<u8>) -> Result<TlpPacket, TlpError> {
         if bytes.len() < 4 {
             return Err(TlpError::InvalidLength);
         }
@@ -833,7 +880,7 @@ impl TlpPacket {
         header.clone_from_slice(&ownbytes[0..4]);
         let data = ownbytes.drain(4..).collect();
         Ok(TlpPacket {
-            header: TlpPacketHeader::new(header)?,
+            header: TlpPacketHeader::new_non_flit(header)?,
             data,
         })
     }
@@ -986,23 +1033,72 @@ mod tests {
   
     #[test]
     fn packet_new_rejects_empty_input() {
-        assert!(matches!(TlpPacket::new(vec![]), Err(TlpError::InvalidLength)));
+        assert!(matches!(TlpPacket::new(vec![], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
     }
 
     #[test]
     fn packet_new_rejects_3_bytes() {
-        assert!(matches!(TlpPacket::new(vec![0x00, 0x00, 0x00]), Err(TlpError::InvalidLength)));
+        assert!(matches!(TlpPacket::new(vec![0x00, 0x00, 0x00], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
     }
 
     #[test]
     fn packet_new_accepts_4_bytes() {
         // Exactly 4 bytes = header only, no data — should succeed
-        assert!(TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00]).is_ok());
+        assert!(TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).is_ok());
     }
 
     #[test]
     fn packet_header_new_rejects_short_input() {
-        assert!(matches!(TlpPacketHeader::new(vec![0x00, 0x00]), Err(TlpError::InvalidLength)));
+        assert!(matches!(TlpPacketHeader::new(vec![0x00, 0x00], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
+    }
+
+    // ── TlpMode: Flit returns NotImplemented ──────────────────────────────
+
+    #[test]
+    fn packet_new_flit_returns_not_implemented() {
+        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+    }
+
+    #[test]
+    fn packet_header_new_flit_returns_not_implemented() {
+        let bytes = vec![0x00, 0x00, 0x00, 0x00];
+        assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+    }
+
+    // ── TlpMode: derive traits ─────────────────────────────────────────────
+
+    #[test]
+    fn tlp_mode_debug_and_partialeq() {
+        assert_eq!(TlpMode::NonFlit, TlpMode::NonFlit);
+        assert_ne!(TlpMode::NonFlit, TlpMode::Flit);
+        let s = format!("{:?}", TlpMode::NonFlit);
+        assert!(s.contains("NonFlit"));
+        let s2 = format!("{:?}", TlpMode::Flit);
+        assert!(s2.contains("Flit"));
+    }
+
+    #[test]
+    fn tlp_mode_copy_and_clone() {
+        let m = TlpMode::NonFlit;
+        let m2 = m; // Copy
+        let m3 = m.clone(); // Clone
+        assert_eq!(m2, TlpMode::NonFlit);
+        assert_eq!(m3, TlpMode::NonFlit);
+    }
+
+    // ── TlpError::NotImplemented ──────────────────────────────────────────
+
+    #[test]
+    fn not_implemented_error_is_distinct() {
+        let e = TlpError::NotImplemented;
+        assert_ne!(e, TlpError::InvalidFormat);
+        assert_ne!(e, TlpError::InvalidType);
+        assert_ne!(e, TlpError::UnsupportedCombination);
+        assert_ne!(e, TlpError::InvalidLength);
+        assert_eq!(e, TlpError::NotImplemented);
+        let s = format!("{:?}", e);
+        assert!(s.contains("NotImplemented"));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -1192,7 +1288,7 @@ mod tests {
             0xAB, 0xCD, 0x42, 0x0F, // req_id=0xABCD, tag=0x42, BE=0x0F
             0xDE, 0xAD, 0x00, 0x00, // address32=0xDEAD0000
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b11011, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b11011, &payload), TlpMode::NonFlit).unwrap();
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
@@ -1210,7 +1306,7 @@ mod tests {
             0x11, 0x22, 0x33, 0x44, // address64 hi
             0x55, 0x66, 0x77, 0x88, // address64 lo
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b11011, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b11011, &payload), TlpMode::NonFlit).unwrap();
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
@@ -1273,7 +1369,7 @@ mod tests {
             0x89, 0xAB, 0xCD, 0xEF, // address32
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload), TlpMode::NonFlit).unwrap();
 
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
@@ -1302,7 +1398,7 @@ mod tests {
             0x55, 0x66, 0x77, 0x88, // address64 low DW
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload), TlpMode::NonFlit).unwrap();
 
         assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
         assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
@@ -1327,7 +1423,7 @@ mod tests {
             0xC0, 0x01, 0x00, 0x04, // address32
             0x00, 0x00, 0x00, 0x0A, // addend (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &payload), TlpMode::NonFlit).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::FetchAdd);
@@ -1350,7 +1446,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // address64
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // addend (W64)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01100, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01100, &payload), TlpMode::NonFlit).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::FetchAdd);
@@ -1373,7 +1469,7 @@ mod tests {
             0xF0, 0x00, 0x00, 0x08, // address32
             0xAB, 0xCD, 0xEF, 0x01, // new_value (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01101, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01101, &payload), TlpMode::NonFlit).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::Swap);
@@ -1398,7 +1494,7 @@ mod tests {
             0xCA, 0xFE, 0xBA, 0xBE, // compare (W32)
             0xDE, 0xAD, 0xBE, 0xEF, // swap    (W32)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01110, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01110, &payload), TlpMode::NonFlit).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::CompareSwap);
@@ -1423,7 +1519,7 @@ mod tests {
             0x01, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02, 0x02, // compare (W64)
             0x03, 0x03, 0x03, 0x03, 0x04, 0x04, 0x04, 0x04, // swap    (W64)
         ];
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &payload)).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &payload), TlpMode::NonFlit).unwrap();
         let ar  = new_atomic_req(&pkt).unwrap();
 
         assert_eq!(ar.op(),       AtomicOp::CompareSwap);
@@ -1438,7 +1534,7 @@ mod tests {
     #[test]
     fn atomic_req_rejects_wrong_tlp_type() {
         // MemRead type is not an atomic — should get UnsupportedCombination
-        let pkt = TlpPacket::new(mk_tlp(0b000, 0b00000, &[0u8; 16])).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b000, 0b00000, &[0u8; 16]), TlpMode::NonFlit).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
     }
 
@@ -1446,29 +1542,29 @@ mod tests {
     fn atomic_req_rejects_wrong_format() {
         // FetchAdd type with NoData3DW format is an invalid combo:
         // get_tlp_type() returns UnsupportedCombination, which propagates
-        let pkt = TlpPacket::new(mk_tlp(0b000, 0b01100, &[0u8; 16])).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b000, 0b01100, &[0u8; 16]), TlpMode::NonFlit).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
     }
 
     #[test]
     fn atomic_req_rejects_short_payload() {
         // 3 bytes data — FetchAdd 3DW needs exactly 12 (8 hdr + 4 operand)
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 3])).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 3]), TlpMode::NonFlit).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
 
         // 8 bytes data — header OK but operand missing (needs 12)
-        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 8])).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &[0u8; 8]), TlpMode::NonFlit).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
 
         // 20 bytes data — CAS 4DW needs exactly 28 (12 hdr + 8 + 8)
-        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &[0u8; 20])).unwrap();
+        let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &[0u8; 20]), TlpMode::NonFlit).unwrap();
         assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::InvalidLength);
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
     fn mk_pkt(fmt: u8, typ: u8, data: &[u8]) -> TlpPacket {
-        TlpPacket::new(mk_tlp(fmt, typ, data)).unwrap()
+        TlpPacket::new(mk_tlp(fmt, typ, data), TlpMode::NonFlit).unwrap()
     }
 
     // ── atomic tier-B (new API): real binary layout, single-argument call ─────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,8 +402,13 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
     }
 }
 
-/// Obtain Memory Request trait from bytes in vector as dyn
-/// This is preffered way of dealing with TLP headers as exact format (32/64 bits) is not required
+/// Obtain Memory Request trait from bytes in vector as dyn.
+/// This is the preferred way of dealing with TLP headers when the exact format
+/// (32-bit vs 64-bit) does not need to be known at the call site.
+///
+/// # Errors
+///
+/// - [`TlpError::UnsupportedCombination`] if `format` is `TlpFmt::TlpPrefix`.
 ///
 /// # Examples
 ///
@@ -706,9 +711,13 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 /// Parse an atomic TLP request from a `TlpPacket`.
 ///
 /// The TLP type and format are extracted from the packet header.
-/// Returns `Err(TlpError::UnsupportedCombination)` if the packet does not
-/// encode one of the three atomic op types, and `Err(TlpError::InvalidLength)`
-/// if the data payload has the wrong size for the expected header and operands.
+///
+/// # Errors
+///
+/// - [`TlpError::UnsupportedCombination`] if the packet does not encode one of the
+///   three atomic op types, or if the format field is not `WithData3DW`/`WithData4DW`.
+/// - [`TlpError::InvalidLength`] if the data payload size does not match
+///   the expected header + operand(s) size for the detected atomic type and width.
 ///
 /// # Examples
 ///
@@ -1058,6 +1067,11 @@ impl TlpPacketHeader {
     /// Use `TlpMode::NonFlit` for PCIe 1.0–5.0 standard TLP framing.
     /// `TlpMode::Flit` is reserved for future PCIe 6.0 support and currently
     /// returns `Err(TlpError::NotImplemented)`.
+    ///
+    /// # Errors
+    ///
+    /// - [`TlpError::InvalidLength`] if `bytes.len() < 4`.
+    /// - [`TlpError::NotImplemented`] if `mode` is `TlpMode::Flit`.
     pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacketHeader, TlpError> {
         match mode {
             TlpMode::NonFlit => Self::new_non_flit(bytes),
@@ -1075,10 +1089,19 @@ impl TlpPacketHeader {
         Ok(TlpPacketHeader { header: TlpHeader(dw0) })
     }
 
+    /// Decode and return the TLP type from the DW0 header fields.
+    ///
+    /// # Errors
+    ///
+    /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is not a known value.
+    /// - [`TlpError::InvalidType`] if the 5-bit Type field is not a known value.
+    /// - [`TlpError::UnsupportedCombination`] if Fmt and Type are individually valid
+    ///   but not a legal pair (e.g. IO Request with 4DW header).
     pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
         self.header.get_tlp_type()
     }
 
+    /// Raw 3-bit Format field from DW0 (`bits[2:0]` of byte 0 in MSB0 layout).
     pub fn get_format(&self) -> u32 {self.header.get_format()}
     pub fn get_type(&self) -> u32 {self.header.get_type()}
     pub fn get_t9(&self) -> u32 {self.header.get_t9()}
@@ -1157,6 +1180,12 @@ impl TlpPacket {
     ///
     /// Use `TlpMode::NonFlit` for standard PCIe 1.0–5.0 TLP framing.
     /// Use `TlpMode::Flit` for PCIe 6.x flit-mode TLP framing.
+    ///
+    /// # Errors
+    ///
+    /// - [`TlpError::InvalidLength`] if `bytes.len() < 4` or the flit header extends beyond `bytes`.
+    /// - [`TlpError::InvalidType`] if flit mode and the DW0 type byte is unknown.
+    /// - [`TlpError::MissingMandatoryOhc`] if flit mode and a mandatory OHC word is absent.
     pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacket, TlpError> {
         match mode {
             TlpMode::NonFlit => Self::new_non_flit(bytes),
@@ -1198,18 +1227,38 @@ impl TlpPacket {
         Ok(TlpPacket { header: dummy, flit_dw0: Some(dw0), data: payload })
     }
 
+    /// Returns a reference to the DW0 packet header.
+    ///
+    /// For flit-mode packets the header fields reflect the dummy all-zero
+    /// placeholder; use [`TlpPacket::get_flit_type`] instead.
     pub fn get_header(&self) -> &TlpPacketHeader {
         &self.header
     }
 
+    /// Returns the packet payload bytes (everything after the 4-byte DW0 header)
+    /// as an owned `Vec<u8>`.
+    ///
+    /// For flit-mode read requests this will be empty even when `Length > 0`.
     pub fn get_data(&self) -> Vec<u8> {
         self.data.to_vec()
     }
 
+    /// Decode and return the TLP type from the DW0 header fields.
+    ///
+    /// # Errors
+    ///
+    /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is unknown.
+    /// - [`TlpError::InvalidType`] if the 5-bit Type field is unknown.
+    /// - [`TlpError::UnsupportedCombination`] if the Fmt/Type pair is not legal.
     pub fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
         self.header.get_tlp_type()
     }
 
+    /// Decode and return the TLP format (3DW/4DW, with/without data) from DW0.
+    ///
+    /// # Errors
+    ///
+    /// - [`TlpError::InvalidFormat`] if the 3-bit Fmt field is not a known value.
     pub fn get_tlp_format(&self) -> Result<TlpFmt, TlpError> {
         TlpFmt::try_from(self.header.get_format())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,12 +481,12 @@ pub trait ConfigurationRequest {
 /// let tlp = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
 ///
 /// if let Ok(tlpfmt) = tlp.get_tlp_format() {
-///     let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.get_data(), &tlpfmt);
+///     let config_req: Box<dyn ConfigurationRequest> = new_conf_req(tlp.get_data());
 ///
 ///     //println!("Configuration Request Bus: {:x}", config_req.bus_nr());
 /// }
 /// ```
-pub fn new_conf_req(bytes: Vec<u8>, _format: &TlpFmt) -> Box<dyn ConfigurationRequest> {
+pub fn new_conf_req(bytes: Vec<u8>) -> Box<dyn ConfigurationRequest> {
 	Box::new(ConfigRequest(bytes))
 }
 
@@ -595,11 +595,11 @@ impl <T: AsRef<[u8]>> CompletionRequest for CompletionReqDW23<T> {
 /// // TLP Format usually comes from TlpPacket or Header here we made up one for example
 /// let tlpfmt = TlpFmt::WithDataHeader4DW;
 ///
-/// let cmpl_req: Box<dyn CompletionRequest> = new_cmpl_req(bytes, &tlpfmt);
+/// let cmpl_req: Box<dyn CompletionRequest> = new_cmpl_req(bytes);
 ///
 /// println!("Requester ID from Completion{}", cmpl_req.req_id());
 /// ```
-pub fn new_cmpl_req(bytes: Vec<u8>, _format: &TlpFmt) -> Box<dyn CompletionRequest> {
+pub fn new_cmpl_req(bytes: Vec<u8>) -> Box<dyn CompletionRequest> {
 	Box::new(CompletionReqDW23(bytes))
 }
 
@@ -655,11 +655,11 @@ impl <T: AsRef<[u8]>> MessageRequest for MessageReqDW24<T> {
 /// let bytes = vec![0x20, 0x01, 0xFF, 0xC2, 0x00, 0x00, 0x00, 0x00];
 /// let tlpfmt = TlpFmt::NoDataHeader3DW;
 ///
-/// let msg_req: Box<dyn MessageRequest> = new_msg_req(bytes, &tlpfmt);
+/// let msg_req: Box<dyn MessageRequest> = new_msg_req(bytes);
 ///
 /// println!("Requester ID from Message{}", msg_req.req_id());
 /// ```
-pub fn new_msg_req(bytes: Vec<u8>, _format: &TlpFmt) -> Box<dyn MessageRequest> {
+pub fn new_msg_req(bytes: Vec<u8>) -> Box<dyn MessageRequest> {
 	Box::new(MessageReqDW24(bytes))
 }
 
@@ -1156,13 +1156,13 @@ impl TlpPacketHeader {
 ///      TlpType::ConfType0ReadReq |
 ///      TlpType::ConfType0WriteReq |
 ///      TlpType::ConfType1ReadReq |
-///      TlpType::ConfType1WriteReq => requester_id = new_conf_req(packet.get_data(), &tlp_format).req_id(),
+///      TlpType::ConfType1WriteReq => requester_id = new_conf_req(packet.get_data()).req_id(),
 ///      TlpType::MsgReq |
-///      TlpType::MsgReqData => requester_id = new_msg_req(packet.get_data(), &tlp_format).req_id(),
+///      TlpType::MsgReqData => requester_id = new_msg_req(packet.get_data()).req_id(),
 ///      TlpType::Cpl |
 ///      TlpType::CplData |
 ///      TlpType::CplLocked |
-///      TlpType::CplDataLocked => requester_id = new_cmpl_req(packet.get_data(), &tlp_format).req_id(),
+///      TlpType::CplDataLocked => requester_id = new_cmpl_req(packet.get_data()).req_id(),
 ///      TlpType::LocalTlpPrefix |
 ///      TlpType::EndToEndTlpPrefix => println!("I need to implement TLP Type: {:?}", tlp_type),
 /// }
@@ -2048,7 +2048,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, // completer_id, cmpl_stat, bcm, byte_cnt
             0x00, 0x00, 0x00, 0x7F, // req_id, tag, R=0, laddr=0x7F
         ];
-        let cmpl = new_cmpl_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.laddr(), 0x7F);
     }
 
@@ -2060,7 +2060,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x40,
         ];
-        let cmpl = new_cmpl_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.laddr(), 0x40);
     }
 
@@ -2072,7 +2072,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0xD5,
         ];
-        let cmpl = new_cmpl_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.laddr(), 0x55);
     }
 
@@ -2084,7 +2084,7 @@ mod tests {
             0x20, 0x01, 0x00, 0xFC, // completer_id=0x2001, status=0, bcm=0, byte_cnt=0x0FC
             0x12, 0x34, 0xAB, 0x64, // req_id=0x1234, tag=0xAB, R=0, laddr=0x64
         ];
-        let cmpl = new_cmpl_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.cmpl_id(), 0x2001);
         assert_eq!(cmpl.byte_cnt(), 0x0FC);
         assert_eq!(cmpl.req_id(), 0x1234);
@@ -2115,7 +2115,7 @@ mod tests {
             0xDE, 0xAD, 0xBE, 0xEF, // DW3
             0x00, 0x00, 0x00, 0x00, // DW4
         ];
-        let msg = new_msg_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let msg = new_msg_req(bytes);
         assert_eq!(msg.dw3(), 0xDEAD_BEEF);
     }
 
@@ -2127,7 +2127,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, // DW3
             0xCA, 0xFE, 0xBA, 0xBE, // DW4
         ];
-        let msg = new_msg_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let msg = new_msg_req(bytes);
         assert_eq!(msg.dw4(), 0xCAFE_BABE);
     }
 
@@ -2139,7 +2139,7 @@ mod tests {
             0xFF, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF,
         ];
-        let msg = new_msg_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let msg = new_msg_req(bytes);
         assert_eq!(msg.dw3(), 0xFFFF_FFFF);
         assert_eq!(msg.dw4(), 0xFFFF_FFFF);
     }
@@ -2152,7 +2152,7 @@ mod tests {
             0x12, 0x34, 0x56, 0x78,
             0x9A, 0xBC, 0xDE, 0xF0,
         ];
-        let msg = new_msg_req(bytes, &TlpFmt::NoDataHeader3DW);
+        let msg = new_msg_req(bytes);
         assert_eq!(msg.req_id(),   0xABCD);
         assert_eq!(msg.tag(),      0x42);
         assert_eq!(msg.msg_code(), 0x7F);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub enum TlpError {
     InvalidLength,
     /// Feature exists in the API but is not yet implemented
     NotImplemented,
+    /// A TLP type that requires a mandatory OHC word was parsed without it
+    /// (e.g. I/O Write missing OHC-A2, Configuration Write missing OHC-A3)
+    MissingMandatoryOhc,
 }
 
 #[repr(u8)]
@@ -906,6 +909,67 @@ impl FlitDW0 {
             self.length as usize * 4
         };
         header_bytes + payload_bytes
+    }
+}
+
+/// Parsed OHC-A word — the byte layout is shared by OHC-A1, OHC-A2, and OHC-A3.
+///
+/// OHC-A word byte layout (4 bytes, on-wire order):
+///
+/// ```text
+/// Byte 0: flags[7:4] | PASID[19:16]
+/// Byte 1: PASID[15:8]
+/// Byte 2: PASID[7:0]
+/// Byte 3: ldwbe[7:4] | fdwbe[3:0]
+/// ```
+///
+/// Use [`FlitOhcA::from_bytes`] to parse from a byte slice that starts at the
+/// first byte of the OHC-A word (i.e. at offset `base_header_dw * 4` in the TLP).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FlitOhcA {
+    /// 20-bit PASID value extracted from bytes 0–2.
+    pub pasid: u32,
+    /// First DW byte enables (bits [3:0] of byte 3).
+    pub fdwbe: u8,
+    /// Last DW byte enables (bits [7:4] of byte 3).
+    pub ldwbe: u8,
+}
+
+impl FlitOhcA {
+    /// Parse one OHC-A word from the first 4 bytes of `b`.
+    ///
+    /// Returns `Err(TlpError::InvalidLength)` if `b.len() < 4`.
+    pub fn from_bytes(b: &[u8]) -> Result<Self, TlpError> {
+        if b.len() < 4 {
+            return Err(TlpError::InvalidLength);
+        }
+        let pasid = ((b[0] as u32 & 0x0F) << 16)
+            | ((b[1] as u32) << 8)
+            | (b[2] as u32);
+        let fdwbe = b[3] & 0x0F;
+        let ldwbe = (b[3] >> 4) & 0x0F;
+        Ok(FlitOhcA { pasid, fdwbe, ldwbe })
+    }
+}
+
+impl FlitDW0 {
+    /// Validate mandatory OHC rules for this TLP type.
+    ///
+    /// Some flit-mode TLP types **require** an OHC word to be present:
+    /// - `IoWrite` requires OHC-A2 (bit 0 of the OHC bitmap must be set)
+    /// - `CfgWrite0` requires OHC-A3 (bit 0 of the OHC bitmap must be set)
+    ///
+    /// Returns `Err(TlpError::MissingMandatoryOhc)` if the rule is violated.
+    pub fn validate_mandatory_ohc(&self) -> Result<(), TlpError> {
+        match self.tlp_type {
+            FlitTlpType::IoWrite | FlitTlpType::CfgWrite0 => {
+                if self.ohc & 0x01 == 0 {
+                    return Err(TlpError::MissingMandatoryOhc);
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1662,6 +1662,21 @@ mod tests {
         // DMWr: WithData only (3DW and 4DW)
         assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
         assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+
+        // Message Requests: all 6 routing sub-types, no-data → MsgReq, with-data → MsgReqData
+        // Type[4:0]: 10000=routeRC, 10001=routeAddr, 10010=routeID,
+        //            10011=broadcast, 10100=local, 10101=gathered
+        for routing in 0b10000u8..=0b10101u8 {
+            assert_eq!(dw0(FMT_3DW_NO_DATA,   routing).get_tlp_type().unwrap(), TlpType::MsgReq,
+                "Fmt=000 Type={:#07b} should be MsgReq", routing);
+            assert_eq!(dw0(FMT_4DW_NO_DATA,   routing).get_tlp_type().unwrap(), TlpType::MsgReq,
+                "Fmt=001 Type={:#07b} should be MsgReq", routing);
+            assert_eq!(dw0(FMT_3DW_WITH_DATA, routing).get_tlp_type().unwrap(), TlpType::MsgReqData,
+                "Fmt=010 Type={:#07b} should be MsgReqData", routing);
+            assert_eq!(dw0(FMT_4DW_WITH_DATA, routing).get_tlp_type().unwrap(), TlpType::MsgReqData,
+                "Fmt=011 Type={:#07b} should be MsgReqData", routing);
+        }
+
     }
 
     // ── negative path: every illegal (fmt, type) pair → UnsupportedCombination ─
@@ -1672,7 +1687,6 @@ mod tests {
         const FMT_4DW_NO_DATA:   u8 = 0b001;
         const FMT_3DW_WITH_DATA: u8 = 0b010;
         const FMT_4DW_WITH_DATA: u8 = 0b011;
-        const FMT_PREFIX:        u8 = 0b100;
 
         const TY_MEM_LK:     u8 = 0b00001;
         const TY_IO:         u8 = 0b00010;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,21 @@ pub enum TlpError {
     MissingMandatoryOhc,
 }
 
+impl fmt::Display for TlpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TlpError::InvalidFormat => write!(f, "invalid TLP format field"),
+            TlpError::InvalidType => write!(f, "invalid TLP type field"),
+            TlpError::UnsupportedCombination => write!(f, "unsupported format/type combination"),
+            TlpError::InvalidLength => write!(f, "byte slice too short for expected TLP fields"),
+            TlpError::NotImplemented => write!(f, "feature not yet implemented"),
+            TlpError::MissingMandatoryOhc => write!(f, "mandatory OHC word missing for this TLP type"),
+        }
+    }
+}
+
+impl std::error::Error for TlpError {}
+
 #[repr(u8)]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TlpFmt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub enum AtomicWidth {
 }
 
 #[derive(PartialEq)]
-pub enum TlpFormatEncodingType {
+pub(crate) enum TlpFormatEncodingType {
     MemoryRequest           = 0b00000,
     MemoryLockRequest       = 0b00001,
     IORequest               = 0b00010,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
-#[macro_use]
-extern crate bitfield;
+use bitfield::bitfield;
 
 /// Selects the framing mode used to interpret the raw byte buffer.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1842,6 +1842,40 @@ mod tests {
         assert!(!TlpType::CplDataLocked.is_non_posted());
     }
 
+    /// Exhaustive is_non_posted() coverage: all 21 TlpType variants explicitly listed.
+    /// A spec change to non-posted semantics will immediately fail the relevant assertion.
+    #[test]
+    fn is_non_posted_exhaustive_all_21_variants() {
+        // --- Non-posted (require a Completion) ---
+        assert!(TlpType::MemReadReq.is_non_posted(),          "MemReadReq must be non-posted");
+        assert!(TlpType::MemReadLockReq.is_non_posted(),      "MemReadLockReq must be non-posted");
+        assert!(TlpType::IOReadReq.is_non_posted(),           "IOReadReq must be non-posted");
+        assert!(TlpType::IOWriteReq.is_non_posted(),          "IOWriteReq must be non-posted");
+        assert!(TlpType::ConfType0ReadReq.is_non_posted(),    "ConfType0ReadReq must be non-posted");
+        assert!(TlpType::ConfType0WriteReq.is_non_posted(),   "ConfType0WriteReq must be non-posted");
+        assert!(TlpType::ConfType1ReadReq.is_non_posted(),    "ConfType1ReadReq must be non-posted");
+        assert!(TlpType::ConfType1WriteReq.is_non_posted(),   "ConfType1WriteReq must be non-posted");
+        assert!(TlpType::FetchAddAtomicOpReq.is_non_posted(), "FetchAddAtomicOpReq must be non-posted");
+        assert!(TlpType::SwapAtomicOpReq.is_non_posted(),     "SwapAtomicOpReq must be non-posted");
+        assert!(TlpType::CompareSwapAtomicOpReq.is_non_posted(), "CompareSwapAtomicOpReq must be non-posted");
+        assert!(TlpType::DeferrableMemWriteReq.is_non_posted(), "DeferrableMemWriteReq must be non-posted");
+
+        // --- Posted (no Completion expected) ---
+        assert!(!TlpType::MemWriteReq.is_non_posted(),        "MemWriteReq is posted");
+        assert!(!TlpType::MsgReq.is_non_posted(),             "MsgReq is posted");
+        assert!(!TlpType::MsgReqData.is_non_posted(),         "MsgReqData is posted");
+
+        // --- Completions (responses, not requests) ---
+        assert!(!TlpType::Cpl.is_non_posted(),                "Cpl is a response, not a request");
+        assert!(!TlpType::CplData.is_non_posted(),            "CplData is a response, not a request");
+        assert!(!TlpType::CplLocked.is_non_posted(),          "CplLocked is a response, not a request");
+        assert!(!TlpType::CplDataLocked.is_non_posted(),      "CplDataLocked is a response, not a request");
+
+        // --- Prefixes (not transactions) ---
+        assert!(!TlpType::LocalTlpPrefix.is_non_posted(),     "LocalTlpPrefix is not a transaction");
+        assert!(!TlpType::EndToEndTlpPrefix.is_non_posted(),  "EndToEndTlpPrefix is not a transaction");
+    }
+
     // ── atomic tier-A: real bytes through the full packet pipeline ─────────────
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -909,6 +909,28 @@ impl FlitTlpType {
     }
 }
 
+impl Display for FlitTlpType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            FlitTlpType::Nop                 => "NOP",
+            FlitTlpType::MemRead32           => "Memory Read (32-bit)",
+            FlitTlpType::UioMemRead          => "UIO Memory Read (64-bit)",
+            FlitTlpType::MsgToRc             => "Message routed to RC",
+            FlitTlpType::MemWrite32          => "Memory Write (32-bit)",
+            FlitTlpType::IoWrite             => "I/O Write",
+            FlitTlpType::CfgWrite0           => "Config Type 0 Write",
+            FlitTlpType::FetchAdd32          => "FetchAdd AtomicOp (32-bit)",
+            FlitTlpType::CompareSwap32       => "CompareSwap AtomicOp (32-bit)",
+            FlitTlpType::DeferrableMemWrite32=> "Deferrable Memory Write (32-bit)",
+            FlitTlpType::UioMemWrite         => "UIO Memory Write (64-bit)",
+            FlitTlpType::MsgDToRc            => "Message with Data routed to RC",
+            FlitTlpType::LocalTlpPrefix      => "Local TLP Prefix",
+            _                                => "Unknown FlitTlpType",
+        };
+        write!(f, "{name}")
+    }
+}
+
 impl TryFrom<u8> for FlitTlpType {
     type Error = TlpError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -799,9 +799,9 @@ pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpErro
         ]),
     };
 
-    let operand0 = read_operand_be(&bytes, hdr_len, width);
+    let operand0 = read_operand_be(bytes, hdr_len, width);
     let operand1 = if matches!(op, AtomicOp::CompareSwap) {
-        Some(read_operand_be(&bytes, hdr_len + op_size, width))
+        Some(read_operand_be(bytes, hdr_len + op_size, width))
     } else {
         None
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,9 @@ impl fmt::Display for TlpError {
             TlpError::UnsupportedCombination => write!(f, "unsupported format/type combination"),
             TlpError::InvalidLength => write!(f, "byte slice too short for expected TLP fields"),
             TlpError::NotImplemented => write!(f, "feature not yet implemented"),
-            TlpError::MissingMandatoryOhc => write!(f, "mandatory OHC word missing for this TLP type"),
+            TlpError::MissingMandatoryOhc => {
+                write!(f, "mandatory OHC word missing for this TLP type")
+            }
         }
     }
 }
@@ -64,15 +66,15 @@ impl std::error::Error for TlpError {}
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TlpFmt {
     /// 3 DW header, no data payload.
-    NoDataHeader3DW     = 0b000,
+    NoDataHeader3DW = 0b000,
     /// 4 DW header, no data payload.
-    NoDataHeader4DW     = 0b001,
+    NoDataHeader4DW = 0b001,
     /// 3 DW header with data payload.
-    WithDataHeader3DW   = 0b010,
+    WithDataHeader3DW = 0b010,
     /// 4 DW header with data payload.
-    WithDataHeader4DW   = 0b011,
+    WithDataHeader4DW = 0b011,
     /// TLP Prefix (not a request or completion).
-    TlpPrefix           = 0b100,
+    TlpPrefix = 0b100,
 }
 
 impl Display for TlpFmt {
@@ -98,7 +100,7 @@ impl TryFrom<u32> for TlpFmt {
             0b010 => Ok(TlpFmt::WithDataHeader3DW),
             0b011 => Ok(TlpFmt::WithDataHeader4DW),
             0b100 => Ok(TlpFmt::TlpPrefix),
-            _     => Err(TlpError::InvalidFormat),
+            _ => Err(TlpError::InvalidFormat),
         }
     }
 }
@@ -125,20 +127,20 @@ pub enum AtomicWidth {
 
 #[derive(PartialEq)]
 pub(crate) enum TlpFormatEncodingType {
-    MemoryRequest           = 0b00000,
-    MemoryLockRequest       = 0b00001,
-    IORequest               = 0b00010,
-    ConfigType0Request      = 0b00100,
-    ConfigType1Request      = 0b00101,
-    Completion              = 0b01010,
-    CompletionLocked        = 0b01011,
-    FetchAtomicOpRequest    = 0b01100,
-    UnconSwapAtomicOpRequest= 0b01101,
+    MemoryRequest = 0b00000,
+    MemoryLockRequest = 0b00001,
+    IORequest = 0b00010,
+    ConfigType0Request = 0b00100,
+    ConfigType1Request = 0b00101,
+    Completion = 0b01010,
+    CompletionLocked = 0b01011,
+    FetchAtomicOpRequest = 0b01100,
+    UnconSwapAtomicOpRequest = 0b01101,
     CompSwapAtomicOpRequest = 0b01110,
     DeferrableMemoryWriteRequest = 0b11011,
     /// Message Request — covers all 6 routing sub-types (0b10000..=0b10101).
     /// Fmt=000/001 → MsgReq, Fmt=010/011 → MsgReqData.
-    MessageRequest          = 0b10000,
+    MessageRequest = 0b10000,
 }
 
 impl TryFrom<u32> for TlpFormatEncodingType {
@@ -160,14 +162,13 @@ impl TryFrom<u32> for TlpFormatEncodingType {
             // All message routing sub-types: route-to-RC, by-addr, by-ID,
             // broadcast, local, gathered — Type[4:3]=10, bits[2:0]=routing
             0b10000..=0b10101 => Ok(TlpFormatEncodingType::MessageRequest),
-            _       => Err(TlpError::InvalidType),
+            _ => Err(TlpError::InvalidType),
         }
     }
 }
 
 /// High-level TLP transaction type decoded from the DW0 Format and Type fields.
-#[derive(PartialEq)]
-#[derive(Debug)]
+#[derive(PartialEq, Debug)]
 pub enum TlpType {
     /// 32-bit or 64-bit Memory Read Request.
     MemReadReq,
@@ -248,14 +249,20 @@ impl TlpType {
     /// Non-posted transactions include memory reads, I/O, configuration, atomics,
     /// and Deferrable Memory Write. Posted writes (`MemWriteReq`, messages) return `false`.
     pub fn is_non_posted(&self) -> bool {
-        matches!(self,
-            TlpType::MemReadReq |
-            TlpType::MemReadLockReq |
-            TlpType::IOReadReq | TlpType::IOWriteReq |
-            TlpType::ConfType0ReadReq | TlpType::ConfType0WriteReq |
-            TlpType::ConfType1ReadReq | TlpType::ConfType1WriteReq |
-            TlpType::FetchAddAtomicOpReq | TlpType::SwapAtomicOpReq | TlpType::CompareSwapAtomicOpReq |
-            TlpType::DeferrableMemWriteReq
+        matches!(
+            self,
+            TlpType::MemReadReq
+                | TlpType::MemReadLockReq
+                | TlpType::IOReadReq
+                | TlpType::IOWriteReq
+                | TlpType::ConfType0ReadReq
+                | TlpType::ConfType0WriteReq
+                | TlpType::ConfType1ReadReq
+                | TlpType::ConfType1WriteReq
+                | TlpType::FetchAddAtomicOpReq
+                | TlpType::SwapAtomicOpReq
+                | TlpType::CompareSwapAtomicOpReq
+                | TlpType::DeferrableMemWriteReq
         )
     }
 
@@ -296,7 +303,6 @@ bitfield! {
 }
 
 impl<T: AsRef<[u8]>> TlpHeader<T> {
-
     fn get_tlp_type(&self) -> Result<TlpType, TlpError> {
         let tlp_type = self.get_type();
         let tlp_fmt = self.get_format();
@@ -312,107 +318,89 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
         }
 
         match TlpFormatEncodingType::try_from(tlp_type) {
-            Ok(TlpFormatEncodingType::MemoryRequest) => {
+            Ok(TlpFormatEncodingType::MemoryRequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::MemReadReq),
+                Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MemReadReq),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::MemWriteReq),
+                Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::MemWriteReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::MemoryLockRequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::MemReadLockReq),
+                Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MemReadLockReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::IORequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::IOReadReq),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::IOWriteReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::ConfigType0Request) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::ConfType0ReadReq),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::ConfType0WriteReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::ConfigType1Request) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::ConfType1ReadReq),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::ConfType1WriteReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::Completion) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::Cpl),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CplData),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::CompletionLocked) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::CplLocked),
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CplDataLocked),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::FetchAtomicOpRequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::FetchAddAtomicOpReq),
+                Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::FetchAddAtomicOpReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::UnconSwapAtomicOpRequest) => {
                 match TlpFmt::try_from(tlp_fmt) {
-                    Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::MemReadReq),
-                    Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MemReadReq),
-                    Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::MemWriteReq),
-                    Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::MemWriteReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
+                    Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::SwapAtomicOpReq),
+                    Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::SwapAtomicOpReq),
+                    Ok(_) => Err(TlpError::UnsupportedCombination),
+                    Err(e) => Err(e),
                 }
             }
-            Ok(TlpFormatEncodingType::MemoryLockRequest) => {
+            Ok(TlpFormatEncodingType::CompSwapAtomicOpRequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CompareSwapAtomicOpReq),
+                Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::CompareSwapAtomicOpReq),
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Ok(TlpFormatEncodingType::DeferrableMemoryWriteRequest) => {
                 match TlpFmt::try_from(tlp_fmt) {
-                    Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::MemReadLockReq),
-                    Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MemReadLockReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
+                    Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::DeferrableMemWriteReq),
+                    Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::DeferrableMemWriteReq),
+                    Ok(_) => Err(TlpError::UnsupportedCombination),
+                    Err(e) => Err(e),
                 }
             }
-			Ok(TlpFormatEncodingType::IORequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::IOReadReq),
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::IOWriteReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::ConfigType0Request) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::ConfType0ReadReq),
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::ConfType0WriteReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-            Ok(TlpFormatEncodingType::ConfigType1Request) => {
-                    match TlpFmt::try_from(tlp_fmt) {
-                            Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::ConfType1ReadReq),
-                            Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::ConfType1WriteReq),
-                            Ok(_) => Err(TlpError::UnsupportedCombination),
-							Err(e) => Err(e),
-                    }
-            }
-			Ok(TlpFormatEncodingType::Completion) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::Cpl),
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CplData),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::CompletionLocked) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::NoDataHeader3DW) => Ok(TlpType::CplLocked),
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CplDataLocked),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::FetchAtomicOpRequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::FetchAddAtomicOpReq),
-					Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::FetchAddAtomicOpReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::UnconSwapAtomicOpRequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::SwapAtomicOpReq),
-					Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::SwapAtomicOpReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::CompSwapAtomicOpRequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::CompareSwapAtomicOpReq),
-					Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::CompareSwapAtomicOpReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Ok(TlpFormatEncodingType::DeferrableMemoryWriteRequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::WithDataHeader3DW) => Ok(TlpType::DeferrableMemWriteReq),
-					Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::DeferrableMemWriteReq),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			// Message Requests: all 6 routing sub-types map here.
-			// Fmt=000/001 (no data) → MsgReq; Fmt=010/011 (with data) → MsgReqData.
-			Ok(TlpFormatEncodingType::MessageRequest) => {
-				match TlpFmt::try_from(tlp_fmt) {
-					Ok(TlpFmt::NoDataHeader3DW) | Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MsgReq),
-					Ok(TlpFmt::WithDataHeader3DW) | Ok(TlpFmt::WithDataHeader4DW) => Ok(TlpType::MsgReqData),
-					Ok(_) => Err(TlpError::UnsupportedCombination),
-					Err(e) => Err(e),
-				}
-			}
-			Err(e) => Err(e)
+            // Message Requests: all 6 routing sub-types map here.
+            // Fmt=000/001 (no data) → MsgReq; Fmt=010/011 (with data) → MsgReqData.
+            Ok(TlpFormatEncodingType::MessageRequest) => match TlpFmt::try_from(tlp_fmt) {
+                Ok(TlpFmt::NoDataHeader3DW) | Ok(TlpFmt::NoDataHeader4DW) => Ok(TlpType::MsgReq),
+                Ok(TlpFmt::WithDataHeader3DW) | Ok(TlpFmt::WithDataHeader4DW) => {
+                    Ok(TlpType::MsgReqData)
+                }
+                Ok(_) => Err(TlpError::UnsupportedCombination),
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
         }
     }
 }
@@ -436,9 +424,10 @@ pub trait MemRequest {
     fn fdwbe(&self) -> u8;
 }
 
-/// Bitfield structure for both 3DW Memory Request and Legacy IO Request headers.
+// Bitfield structure for both 3DW Memory Request and Legacy IO Request headers.
 // Structure for both 3DW Memory Request as well as Legacy IO Request
 bitfield! {
+    #[allow(missing_docs)]
     pub struct MemRequest3DW(MSB0 [u8]);
     u32;
     /// Returns the Requester ID field.
@@ -453,8 +442,9 @@ bitfield! {
     pub get_address32,      _: 63, 32;
 }
 
-/// Bitfield structure for 4DW Memory Request headers.
+// Bitfield structure for 4DW Memory Request headers.
 bitfield! {
+    #[allow(missing_docs)]
     pub struct MemRequest4DW(MSB0 [u8]);
     u64;
     /// Returns the Requester ID field.
@@ -469,7 +459,7 @@ bitfield! {
     pub get_address64,      _: 95, 32;
 }
 
-impl <T: AsRef<[u8]>> MemRequest for MemRequest3DW<T> {
+impl<T: AsRef<[u8]>> MemRequest for MemRequest3DW<T> {
     fn address(&self) -> u64 {
         self.get_address32().into()
     }
@@ -487,7 +477,7 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest3DW<T> {
     }
 }
 
-impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
+impl<T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
     fn address(&self) -> u64 {
         self.get_address64()
     }
@@ -544,14 +534,17 @@ impl <T: AsRef<[u8]>> MemRequest for MemRequest4DW<T> {
 /// # let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 /// # decode(bytes).unwrap();
 /// ```
-pub fn new_mem_req(bytes: impl Into<Vec<u8>>, format: &TlpFmt) -> Result<Box<dyn MemRequest>, TlpError> {
+pub fn new_mem_req(
+    bytes: impl Into<Vec<u8>>,
+    format: &TlpFmt,
+) -> Result<Box<dyn MemRequest>, TlpError> {
     let bytes = bytes.into();
     match format {
-        TlpFmt::NoDataHeader3DW   => Ok(Box::new(MemRequest3DW(bytes))),
-        TlpFmt::NoDataHeader4DW   => Ok(Box::new(MemRequest4DW(bytes))),
+        TlpFmt::NoDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
+        TlpFmt::NoDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
         TlpFmt::WithDataHeader3DW => Ok(Box::new(MemRequest3DW(bytes))),
         TlpFmt::WithDataHeader4DW => Ok(Box::new(MemRequest4DW(bytes))),
-        TlpFmt::TlpPrefix         => Err(TlpError::UnsupportedCombination),
+        TlpFmt::TlpPrefix => Err(TlpError::UnsupportedCombination),
     }
 }
 
@@ -603,11 +596,12 @@ pub trait ConfigurationRequest {
 /// assert_eq!(config_req.bus_nr(), 0xC2);
 /// ```
 pub fn new_conf_req(bytes: impl Into<Vec<u8>>) -> Box<dyn ConfigurationRequest> {
-	Box::new(ConfigRequest(bytes.into()))
+    Box::new(ConfigRequest(bytes.into()))
 }
 
-/// Bitfield structure for Configuration Request headers (DW1+DW2).
+// Bitfield structure for Configuration Request headers (DW1+DW2).
 bitfield! {
+    #[allow(missing_docs)]
     pub struct ConfigRequest(MSB0 [u8]);
     u32;
     /// Returns the Requester ID field.
@@ -633,7 +627,7 @@ bitfield! {
     r,                      _: 63, 62;
 }
 
-impl <T: AsRef<[u8]>> ConfigurationRequest for ConfigRequest<T> {
+impl<T: AsRef<[u8]>> ConfigurationRequest for ConfigRequest<T> {
     fn req_id(&self) -> u16 {
         self.get_requester_id() as u16
     }
@@ -679,8 +673,9 @@ pub trait CompletionRequest {
     fn laddr(&self) -> u8;
 }
 
-/// Bitfield structure for Completion Request DW2+DW3 fields.
+// Bitfield structure for Completion Request DW2+DW3 fields.
 bitfield! {
+    #[allow(missing_docs)]
     pub struct CompletionReqDW23(MSB0 [u8]);
     u16;
     /// Returns the Completer ID field.
@@ -700,7 +695,7 @@ bitfield! {
     pub get_laddr,          _: 63, 57;
 }
 
-impl <T: AsRef<[u8]>> CompletionRequest for CompletionReqDW23<T> {
+impl<T: AsRef<[u8]>> CompletionRequest for CompletionReqDW23<T> {
     fn cmpl_id(&self) -> u16 {
         self.get_completer_id()
     }
@@ -742,7 +737,7 @@ impl <T: AsRef<[u8]>> CompletionRequest for CompletionReqDW23<T> {
 /// println!("Requester ID from Completion{}", cmpl_req.req_id());
 /// ```
 pub fn new_cmpl_req(bytes: impl Into<Vec<u8>>) -> Box<dyn CompletionRequest> {
-	Box::new(CompletionReqDW23(bytes.into()))
+    Box::new(CompletionReqDW23(bytes.into()))
 }
 
 /// Message Request trait
@@ -753,15 +748,16 @@ pub trait MessageRequest {
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the 8-bit Message Code field.
-	fn msg_code(&self) -> u8;
+    fn msg_code(&self) -> u8;
     /// DW3 content — interpretation varies with Message Code.
     fn dw3(&self) -> u32;
     /// DW4 content — interpretation varies with Message Code.
     fn dw4(&self) -> u32;
 }
 
-/// Bitfield structure for Message Request DW2–DW4 fields.
+// Bitfield structure for Message Request DW2–DW4 fields.
 bitfield! {
+    #[allow(missing_docs)]
     pub struct MessageReqDW24(MSB0 [u8]);
     u32;
     /// Returns the Requester ID field.
@@ -776,7 +772,7 @@ bitfield! {
     pub get_dw4,            _: 95, 64;
 }
 
-impl <T: AsRef<[u8]>> MessageRequest for MessageReqDW24<T> {
+impl<T: AsRef<[u8]>> MessageRequest for MessageReqDW24<T> {
     fn req_id(&self) -> u16 {
         self.get_requester_id() as u16
     }
@@ -812,7 +808,7 @@ impl <T: AsRef<[u8]>> MessageRequest for MessageReqDW24<T> {
 /// println!("Requester ID from Message{}", msg_req.req_id());
 /// ```
 pub fn new_msg_req(bytes: impl Into<Vec<u8>>) -> Box<dyn MessageRequest> {
-	Box::new(MessageReqDW24(bytes.into()))
+    Box::new(MessageReqDW24(bytes.into()))
 }
 
 /// Atomic Request trait: header fields and operand(s) for atomic op TLPs.
@@ -836,31 +832,51 @@ pub trait AtomicRequest: std::fmt::Debug {
 
 #[derive(Debug)]
 struct AtomicReq {
-    op:       AtomicOp,
-    width:    AtomicWidth,
-    req_id:   u16,
-    tag:      u8,
-    address:  u64,
+    op: AtomicOp,
+    width: AtomicWidth,
+    req_id: u16,
+    tag: u8,
+    address: u64,
     operand0: u64,
     operand1: Option<u64>,
 }
 
 impl AtomicRequest for AtomicReq {
-    fn op(&self)       -> AtomicOp    { self.op }
-    fn width(&self)    -> AtomicWidth { self.width }
-    fn req_id(&self)   -> u16         { self.req_id }
-    fn tag(&self)      -> u8          { self.tag }
-    fn address(&self)  -> u64         { self.address }
-    fn operand0(&self) -> u64         { self.operand0 }
-    fn operand1(&self) -> Option<u64> { self.operand1 }
+    fn op(&self) -> AtomicOp {
+        self.op
+    }
+    fn width(&self) -> AtomicWidth {
+        self.width
+    }
+    fn req_id(&self) -> u16 {
+        self.req_id
+    }
+    fn tag(&self) -> u8 {
+        self.tag
+    }
+    fn address(&self) -> u64 {
+        self.address
+    }
+    fn operand0(&self) -> u64 {
+        self.operand0
+    }
+    fn operand1(&self) -> Option<u64> {
+        self.operand1
+    }
 }
 
 fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
     match width {
-        AtomicWidth::W32 => u32::from_be_bytes([b[off], b[off+1], b[off+2], b[off+3]]) as u64,
+        AtomicWidth::W32 => u32::from_be_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]]) as u64,
         AtomicWidth::W64 => u64::from_be_bytes([
-            b[off], b[off+1], b[off+2], b[off+3],
-            b[off+4], b[off+5], b[off+6], b[off+7],
+            b[off],
+            b[off + 1],
+            b[off + 2],
+            b[off + 3],
+            b[off + 4],
+            b[off + 5],
+            b[off + 6],
+            b[off + 7],
         ]),
     }
 }
@@ -896,33 +912,41 @@ fn read_operand_be(b: &[u8], off: usize, width: AtomicWidth) -> u64 {
 /// ```
 pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpError> {
     let tlp_type = pkt.tlp_type()?;
-    let format   = pkt.tlp_format()?;
-    let bytes    = pkt.data();
+    let format = pkt.tlp_format()?;
+    let bytes = pkt.data();
 
     let op = match tlp_type {
-        TlpType::FetchAddAtomicOpReq    => AtomicOp::FetchAdd,
-        TlpType::SwapAtomicOpReq        => AtomicOp::Swap,
+        TlpType::FetchAddAtomicOpReq => AtomicOp::FetchAdd,
+        TlpType::SwapAtomicOpReq => AtomicOp::Swap,
         TlpType::CompareSwapAtomicOpReq => AtomicOp::CompareSwap,
-        _                               => return Err(TlpError::UnsupportedCombination),
+        _ => return Err(TlpError::UnsupportedCombination),
     };
     let (width, hdr_len) = match format {
         TlpFmt::WithDataHeader3DW => (AtomicWidth::W32, 8usize),
         TlpFmt::WithDataHeader4DW => (AtomicWidth::W64, 12usize),
-        _                         => return Err(TlpError::UnsupportedCombination),
+        _ => return Err(TlpError::UnsupportedCombination),
     };
 
-    let op_size = match width { AtomicWidth::W32 => 4usize, AtomicWidth::W64 => 8usize };
-    let num_ops = if matches!(op, AtomicOp::CompareSwap) { 2 } else { 1 };
-    let needed  = hdr_len + op_size * num_ops;
-    if bytes.len() != needed { return Err(TlpError::InvalidLength); }
+    let op_size = match width {
+        AtomicWidth::W32 => 4usize,
+        AtomicWidth::W64 => 8usize,
+    };
+    let num_ops = if matches!(op, AtomicOp::CompareSwap) {
+        2
+    } else {
+        1
+    };
+    let needed = hdr_len + op_size * num_ops;
+    if bytes.len() != needed {
+        return Err(TlpError::InvalidLength);
+    }
 
-    let req_id  = u16::from_be_bytes([bytes[0], bytes[1]]);
-    let tag     = bytes[2];
+    let req_id = u16::from_be_bytes([bytes[0], bytes[1]]);
+    let tag = bytes[2];
     let address = match width {
         AtomicWidth::W32 => u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as u64,
         AtomicWidth::W64 => u64::from_be_bytes([
-            bytes[4], bytes[5], bytes[6],  bytes[7],
-            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11],
         ]),
     };
 
@@ -933,7 +957,15 @@ pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpErro
         None
     };
 
-    Ok(Box::new(AtomicReq { op, width, req_id, tag, address, operand0, operand1 }))
+    Ok(Box::new(AtomicReq {
+        op,
+        width,
+        req_id,
+        tag,
+        address,
+        operand0,
+        operand1,
+    }))
 }
 
 // ============================================================================
@@ -1007,11 +1039,16 @@ impl FlitTlpType {
     /// - NOP and Local TLP Prefix (management objects with no data)
     /// - Message-without-data variants (`MsgToRc`)
     pub fn has_data_payload(&self) -> bool {
-        matches!(self,
-            FlitTlpType::MemWrite32 | FlitTlpType::UioMemWrite
-            | FlitTlpType::IoWrite | FlitTlpType::CfgWrite0
-            | FlitTlpType::FetchAdd32 | FlitTlpType::CompareSwap32
-            | FlitTlpType::DeferrableMemWrite32 | FlitTlpType::MsgDToRc
+        matches!(
+            self,
+            FlitTlpType::MemWrite32
+                | FlitTlpType::UioMemWrite
+                | FlitTlpType::IoWrite
+                | FlitTlpType::CfgWrite0
+                | FlitTlpType::FetchAdd32
+                | FlitTlpType::CompareSwap32
+                | FlitTlpType::DeferrableMemWrite32
+                | FlitTlpType::MsgDToRc
         )
     }
 }
@@ -1019,19 +1056,19 @@ impl FlitTlpType {
 impl Display for FlitTlpType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
-            FlitTlpType::Nop                 => "NOP",
-            FlitTlpType::MemRead32           => "Memory Read (32-bit)",
-            FlitTlpType::UioMemRead          => "UIO Memory Read (64-bit)",
-            FlitTlpType::MsgToRc             => "Message routed to RC",
-            FlitTlpType::MemWrite32          => "Memory Write (32-bit)",
-            FlitTlpType::IoWrite             => "I/O Write",
-            FlitTlpType::CfgWrite0           => "Config Type 0 Write",
-            FlitTlpType::FetchAdd32          => "FetchAdd AtomicOp (32-bit)",
-            FlitTlpType::CompareSwap32       => "CompareSwap AtomicOp (32-bit)",
-            FlitTlpType::DeferrableMemWrite32=> "Deferrable Memory Write (32-bit)",
-            FlitTlpType::UioMemWrite         => "UIO Memory Write (64-bit)",
-            FlitTlpType::MsgDToRc            => "Message with Data routed to RC",
-            FlitTlpType::LocalTlpPrefix      => "Local TLP Prefix",
+            FlitTlpType::Nop => "NOP",
+            FlitTlpType::MemRead32 => "Memory Read (32-bit)",
+            FlitTlpType::UioMemRead => "UIO Memory Read (64-bit)",
+            FlitTlpType::MsgToRc => "Message routed to RC",
+            FlitTlpType::MemWrite32 => "Memory Write (32-bit)",
+            FlitTlpType::IoWrite => "I/O Write",
+            FlitTlpType::CfgWrite0 => "Config Type 0 Write",
+            FlitTlpType::FetchAdd32 => "FetchAdd AtomicOp (32-bit)",
+            FlitTlpType::CompareSwap32 => "CompareSwap AtomicOp (32-bit)",
+            FlitTlpType::DeferrableMemWrite32 => "Deferrable Memory Write (32-bit)",
+            FlitTlpType::UioMemWrite => "UIO Memory Write (64-bit)",
+            FlitTlpType::MsgDToRc => "Message with Data routed to RC",
+            FlitTlpType::LocalTlpPrefix => "Local TLP Prefix",
         };
         write!(f, "{name}")
     }
@@ -1055,7 +1092,7 @@ impl TryFrom<u8> for FlitTlpType {
             0x61 => Ok(FlitTlpType::UioMemWrite),
             0x70 => Ok(FlitTlpType::MsgDToRc),
             0x8D => Ok(FlitTlpType::LocalTlpPrefix),
-            _    => Err(TlpError::InvalidType),
+            _ => Err(TlpError::InvalidType),
         }
     }
 }
@@ -1100,12 +1137,19 @@ impl FlitDW0 {
             return Err(TlpError::InvalidLength);
         }
         let tlp_type = FlitTlpType::try_from(b[0])?;
-        let tc       = (b[1] >> 5) & 0x07;
-        let ohc      = b[1] & 0x1F;
-        let ts       = (b[2] >> 5) & 0x07;
-        let attr     = (b[2] >> 2) & 0x07;
-        let length   = (((b[2] & 0x03) as u16) << 8) | (b[3] as u16);
-        Ok(FlitDW0 { tlp_type, tc, ohc, ts, attr, length })
+        let tc = (b[1] >> 5) & 0x07;
+        let ohc = b[1] & 0x1F;
+        let ts = (b[2] >> 5) & 0x07;
+        let attr = (b[2] >> 2) & 0x07;
+        let length = (((b[2] & 0x03) as u16) << 8) | (b[3] as u16);
+        Ok(FlitDW0 {
+            tlp_type,
+            tc,
+            ohc,
+            ts,
+            attr,
+            length,
+        })
     }
 
     /// Number of OHC extension words present — popcount of [`FlitDW0::ohc`].
@@ -1121,12 +1165,16 @@ impl FlitDW0 {
     /// Types that never carry payload (read requests, NOP, LocalTlpPrefix, MsgToRc)
     /// always contribute zero payload bytes.
     pub fn total_bytes(&self) -> usize {
-        let header_bytes = (self.tlp_type.base_header_dw() as usize
-            + self.ohc_count() as usize) * 4;
+        let header_bytes =
+            (self.tlp_type.base_header_dw() as usize + self.ohc_count() as usize) * 4;
         let payload_bytes = if !self.tlp_type.has_data_payload() {
             0
         } else {
-            let dw_count = if self.length == 0 { 1024 } else { self.length as usize };
+            let dw_count = if self.length == 0 {
+                1024
+            } else {
+                self.length as usize
+            };
             dw_count * 4
         };
         header_bytes + payload_bytes
@@ -1164,12 +1212,14 @@ impl FlitOhcA {
         if b.len() < 4 {
             return Err(TlpError::InvalidLength);
         }
-        let pasid = ((b[0] as u32 & 0x0F) << 16)
-            | ((b[1] as u32) << 8)
-            | (b[2] as u32);
+        let pasid = ((b[0] as u32 & 0x0F) << 16) | ((b[1] as u32) << 8) | (b[2] as u32);
         let fdwbe = b[3] & 0x0F;
         let ldwbe = (b[3] >> 4) & 0x0F;
-        Ok(FlitOhcA { pasid, fdwbe, ldwbe })
+        Ok(FlitOhcA {
+            pasid,
+            fdwbe,
+            ldwbe,
+        })
     }
 }
 
@@ -1223,7 +1273,11 @@ pub struct FlitStreamWalker<'a> {
 impl<'a> FlitStreamWalker<'a> {
     /// Create a new walker over a packed flit TLP byte stream.
     pub fn new(data: &'a [u8]) -> Self {
-        FlitStreamWalker { data, pos: 0, errored: false }
+        FlitStreamWalker {
+            data,
+            pos: 0,
+            errored: false,
+        }
     }
 }
 
@@ -1236,8 +1290,11 @@ impl<'a> Iterator for FlitStreamWalker<'a> {
         }
         let offset = self.pos;
         let dw0 = match FlitDW0::from_dw0(&self.data[self.pos..]) {
-            Ok(d)  => d,
-            Err(e) => { self.errored = true; return Some(Err(e)); }
+            Ok(d) => d,
+            Err(e) => {
+                self.errored = true;
+                return Some(Err(e));
+            }
         };
         let total = dw0.total_bytes();
         if self.pos + total > self.data.len() {
@@ -1262,19 +1319,19 @@ pub struct TlpPacketHeader {
 impl fmt::Debug for TlpPacketHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TlpPacketHeader")
-            .field("format",  &self.header.get_format())
-            .field("type",    &self.header.get_type())
-            .field("tc",      &self.header.get_tc())
-            .field("t9",      &self.header.get_t9())
-            .field("t8",      &self.header.get_t8())
-            .field("attr_b2", &self.header.get_attr_b2())
-            .field("ln",      &self.header.get_ln())
-            .field("th",      &self.header.get_th())
-            .field("td",      &self.header.get_td())
-            .field("ep",      &self.header.get_ep())
-            .field("attr",    &self.header.get_attr())
-            .field("at",      &self.header.get_at())
-            .field("length",  &self.header.get_length())
+            .field("format", &self.get_format())
+            .field("type", &self.get_type())
+            .field("tc", &self.get_tc())
+            .field("t9", &self.get_t9())
+            .field("t8", &self.get_t8())
+            .field("attr_b2", &self.get_attr_b2())
+            .field("ln", &self.get_ln())
+            .field("th", &self.get_th())
+            .field("td", &self.get_td())
+            .field("ep", &self.get_ep())
+            .field("attr", &self.get_attr())
+            .field("at", &self.get_at())
+            .field("length", &self.get_length())
             .finish()
     }
 }
@@ -1304,7 +1361,9 @@ impl TlpPacketHeader {
         let mut dw0 = vec![0; 4];
         dw0[..4].clone_from_slice(&bytes[0..4]);
 
-        Ok(TlpPacketHeader { header: TlpHeader(dw0) })
+        Ok(TlpPacketHeader {
+            header: TlpHeader(dw0),
+        })
     }
 
     /// Decode and return the TLP type from the DW0 header fields.
@@ -1330,21 +1389,47 @@ impl TlpPacketHeader {
     }
 
     /// Raw Traffic Class field from DW0 (`bits[11:9]`).
-    pub fn get_tc(&self) -> u32 { self.header.get_tc() }
+    pub fn get_tc(&self) -> u32 {
+        self.header.get_tc()
+    }
 
     /// Raw 3-bit Format field from DW0 (`bits[2:0]` of byte 0 in MSB0 layout).
-    pub(crate) fn get_format(&self) -> u32 {self.header.get_format()}
-    pub(crate) fn get_type(&self) -> u32 {self.header.get_type()}
-    pub(crate) fn get_t9(&self) -> u32 {self.header.get_t9()}
-    pub(crate) fn get_t8(&self) -> u32 {self.header.get_t8()}
-    pub(crate) fn get_attr_b2(&self) -> u32 {self.header.get_attr_b2()}
-    pub(crate) fn get_ln(&self) -> u32 {self.header.get_ln()}
-    pub(crate) fn get_th(&self) -> u32 {self.header.get_th()}
-    pub(crate) fn get_td(&self) -> u32 {self.header.get_td()}
-    pub(crate) fn get_ep(&self) -> u32 {self.header.get_ep()}
-    pub(crate) fn get_attr(&self) -> u32 {self.header.get_attr()}
-    pub(crate) fn get_at(&self) -> u32 {self.header.get_at()}
-    pub(crate) fn get_length(&self) -> u32 {self.header.get_length()}
+    pub(crate) fn get_format(&self) -> u32 {
+        self.header.get_format()
+    }
+    pub(crate) fn get_type(&self) -> u32 {
+        self.header.get_type()
+    }
+    pub(crate) fn get_t9(&self) -> u32 {
+        self.header.get_t9()
+    }
+    pub(crate) fn get_t8(&self) -> u32 {
+        self.header.get_t8()
+    }
+    pub(crate) fn get_attr_b2(&self) -> u32 {
+        self.header.get_attr_b2()
+    }
+    pub(crate) fn get_ln(&self) -> u32 {
+        self.header.get_ln()
+    }
+    pub(crate) fn get_th(&self) -> u32 {
+        self.header.get_th()
+    }
+    pub(crate) fn get_td(&self) -> u32 {
+        self.header.get_td()
+    }
+    pub(crate) fn get_ep(&self) -> u32 {
+        self.header.get_ep()
+    }
+    pub(crate) fn get_attr(&self) -> u32 {
+        self.header.get_attr()
+    }
+    pub(crate) fn get_at(&self) -> u32 {
+        self.header.get_at()
+    }
+    pub(crate) fn get_length(&self) -> u32 {
+        self.header.get_length()
+    }
 }
 
 /// TLP Packet structure is high level abstraction for entire TLP packet
@@ -1407,7 +1492,7 @@ pub struct TlpPacket {
 impl fmt::Debug for TlpPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TlpPacket")
-            .field("header",   &self.header)
+            .field("header", &self.header)
             .field("flit_dw0", &self.flit_dw0)
             .field("data_len", &self.data.len())
             .finish()
@@ -1428,7 +1513,7 @@ impl TlpPacket {
     pub fn new(bytes: Vec<u8>, mode: TlpMode) -> Result<TlpPacket, TlpError> {
         match mode {
             TlpMode::NonFlit => Self::new_non_flit(bytes),
-            TlpMode::Flit    => Self::new_flit(bytes),
+            TlpMode::Flit => Self::new_flit(bytes),
         }
     }
 
@@ -1454,8 +1539,7 @@ impl TlpPacket {
         let dw0 = FlitDW0::from_dw0(&bytes)?;
         dw0.validate_mandatory_ohc()?;
 
-        let hdr_bytes = (dw0.tlp_type.base_header_dw() as usize
-            + dw0.ohc_count() as usize) * 4;
+        let hdr_bytes = (dw0.tlp_type.base_header_dw() as usize + dw0.ohc_count() as usize) * 4;
         if bytes.len() < hdr_bytes {
             return Err(TlpError::InvalidLength);
         }
@@ -1463,7 +1547,11 @@ impl TlpPacket {
 
         // Use a dummy non-flit header; callers should use flit_type() for type queries.
         let dummy = TlpPacketHeader::new_non_flit(vec![0u8; 4])?;
-        Ok(TlpPacket { header: dummy, flit_dw0: Some(dw0), data: payload })
+        Ok(TlpPacket {
+            header: dummy,
+            flit_dw0: Some(dw0),
+            data: payload,
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -1543,7 +1631,11 @@ impl TlpPacket {
     /// }
     /// ```
     pub fn mode(&self) -> TlpMode {
-        if self.flit_dw0.is_some() { TlpMode::Flit } else { TlpMode::NonFlit }
+        if self.flit_dw0.is_some() {
+            TlpMode::Flit
+        } else {
+            TlpMode::NonFlit
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1633,19 +1725,31 @@ mod tests {
 
         // Config Type 0 Read request: FMT: '000' Type '0 0100'
         let conf_t0_read = TlpHeader([0x04, 0x00, 0x00, 0x01]);
-        assert_eq!(conf_t0_read.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
+        assert_eq!(
+            conf_t0_read.get_tlp_type().unwrap(),
+            TlpType::ConfType0ReadReq
+        );
 
         // Config Type 0 Write request: FMT: '010' Type '0 0100'
         let conf_t0_write = TlpHeader([0x44, 0x00, 0x00, 0x01]);
-        assert_eq!(conf_t0_write.get_tlp_type().unwrap(), TlpType::ConfType0WriteReq);
+        assert_eq!(
+            conf_t0_write.get_tlp_type().unwrap(),
+            TlpType::ConfType0WriteReq
+        );
 
         // Config Type 1 Read request: FMT: '000' Type '0 0101'
         let conf_t1_read = TlpHeader([0x05, 0x88, 0x80, 0x01]);
-        assert_eq!(conf_t1_read.get_tlp_type().unwrap(), TlpType::ConfType1ReadReq);
+        assert_eq!(
+            conf_t1_read.get_tlp_type().unwrap(),
+            TlpType::ConfType1ReadReq
+        );
 
         // Config Type 1 Write request: FMT: '010' Type '0 0101'
         let conf_t1_write = TlpHeader([0x45, 0x88, 0x80, 0x01]);
-        assert_eq!(conf_t1_write.get_tlp_type().unwrap(), TlpType::ConfType1WriteReq);
+        assert_eq!(
+            conf_t1_write.get_tlp_type().unwrap(),
+            TlpType::ConfType1WriteReq
+        );
 
         // HeaderLog: 04000001 0000220f 01070000 af36fc70
         // HeaderLog: 60009001 4000000f 00000280 4047605c
@@ -1697,15 +1801,24 @@ mod tests {
         // byte0 layout: bits[7:5] = fmt, bits[4:0] = type
         // Fmt=0b101 → byte0 = 0b1010_0000 = 0xA0
         let invalid_fmt_101 = TlpHeader([0xa0, 0x00, 0x00, 0x01]);
-        assert_eq!(invalid_fmt_101.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
+        assert_eq!(
+            invalid_fmt_101.get_tlp_type().unwrap_err(),
+            TlpError::InvalidFormat
+        );
 
         // Fmt=0b110 → byte0 = 0b1100_0000 = 0xC0
         let invalid_fmt_110 = TlpHeader([0xc0, 0x00, 0x00, 0x01]);
-        assert_eq!(invalid_fmt_110.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
+        assert_eq!(
+            invalid_fmt_110.get_tlp_type().unwrap_err(),
+            TlpError::InvalidFormat
+        );
 
         // Fmt=0b111 → byte0 = 0b1110_0000 = 0xE0
         let invalid_fmt_111 = TlpHeader([0xe0, 0x00, 0x00, 0x01]);
-        assert_eq!(invalid_fmt_111.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
+        assert_eq!(
+            invalid_fmt_111.get_tlp_type().unwrap_err(),
+            TlpError::InvalidFormat
+        );
     }
 
     #[test]
@@ -1735,17 +1848,23 @@ mod tests {
         let result = new_mem_req(bytes, &TlpFmt::TlpPrefix);
         assert!(matches!(result, Err(TlpError::UnsupportedCombination)));
     }
-  
+
     // ── short packet rejection ─────────────────────────────────────────────
-  
+
     #[test]
     fn packet_new_rejects_empty_input() {
-        assert!(matches!(TlpPacket::new(vec![], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
+        assert!(matches!(
+            TlpPacket::new(vec![], TlpMode::NonFlit),
+            Err(TlpError::InvalidLength)
+        ));
     }
 
     #[test]
     fn packet_new_rejects_3_bytes() {
-        assert!(matches!(TlpPacket::new(vec![0x00, 0x00, 0x00], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
+        assert!(matches!(
+            TlpPacket::new(vec![0x00, 0x00, 0x00], TlpMode::NonFlit),
+            Err(TlpError::InvalidLength)
+        ));
     }
 
     #[test]
@@ -1756,7 +1875,10 @@ mod tests {
 
     #[test]
     fn packet_header_new_rejects_short_input() {
-        assert!(matches!(TlpPacketHeader::new(vec![0x00, 0x00], TlpMode::NonFlit), Err(TlpError::InvalidLength)));
+        assert!(matches!(
+            TlpPacketHeader::new(vec![0x00, 0x00], TlpMode::NonFlit),
+            Err(TlpError::InvalidLength)
+        ));
     }
 
     // ── TlpMode: Flit ─────────────────────────────────────────────────────
@@ -1773,7 +1895,9 @@ mod tests {
     #[test]
     fn packet_new_flit_mrd32_has_no_payload() {
         // MRd32 flit (type 0x03, 3 DW base header, no payload despite Length=1)
-        let bytes = vec![0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let bytes = vec![
+            0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
         assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemRead32));
         assert!(pkt.data().is_empty()); // read request, no payload
@@ -1804,7 +1928,10 @@ mod tests {
     fn packet_header_new_flit_returns_not_implemented() {
         // TlpPacketHeader::new() with Flit still returns NotImplemented
         let bytes = vec![0x00, 0x00, 0x00, 0x00];
-        assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+        assert_eq!(
+            TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(),
+            TlpError::NotImplemented
+        );
     }
 
     // ── TlpMode: derive traits ─────────────────────────────────────────────
@@ -1820,10 +1947,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::clone_on_copy)]
     fn tlp_mode_copy_and_clone() {
         let m = TlpMode::NonFlit;
         let m2 = m; // Copy
-        let m3 = m.clone(); // Clone
+        let m3 = m.clone(); // Verify Clone trait is callable on Copy types
         assert_eq!(m2, TlpMode::NonFlit);
         assert_eq!(m3, TlpMode::NonFlit);
     }
@@ -1866,137 +1994,306 @@ mod tests {
 
     #[test]
     fn header_decode_supported_pairs() {
-        const FMT_3DW_NO_DATA:   u8 = 0b000;
-        const FMT_4DW_NO_DATA:   u8 = 0b001;
+        const FMT_3DW_NO_DATA: u8 = 0b000;
+        const FMT_4DW_NO_DATA: u8 = 0b001;
         const FMT_3DW_WITH_DATA: u8 = 0b010;
         const FMT_4DW_WITH_DATA: u8 = 0b011;
 
-        const TY_MEM:        u8 = 0b00000;
-        const TY_MEM_LK:     u8 = 0b00001;
-        const TY_IO:         u8 = 0b00010;
-        const TY_CFG0:       u8 = 0b00100;
-        const TY_CFG1:       u8 = 0b00101;
-        const TY_CPL:        u8 = 0b01010;
-        const TY_CPL_LK:     u8 = 0b01011;
+        const TY_MEM: u8 = 0b00000;
+        const TY_MEM_LK: u8 = 0b00001;
+        const TY_IO: u8 = 0b00010;
+        const TY_CFG0: u8 = 0b00100;
+        const TY_CFG1: u8 = 0b00101;
+        const TY_CPL: u8 = 0b01010;
+        const TY_CPL_LK: u8 = 0b01011;
         const TY_ATOM_FETCH: u8 = 0b01100;
-        const TY_ATOM_SWAP:  u8 = 0b01101;
-        const TY_ATOM_CAS:   u8 = 0b01110;
-        const TY_DMWR:       u8 = 0b11011;
+        const TY_ATOM_SWAP: u8 = 0b01101;
+        const TY_ATOM_CAS: u8 = 0b01110;
+        const TY_DMWR: u8 = 0b11011;
 
         // Memory Request: NoData → Read, WithData → Write; both 3DW and 4DW
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_MEM).get_tlp_type().unwrap(), TlpType::MemReadReq);
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_MEM).get_tlp_type().unwrap(), TlpType::MemReadReq);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_MEM).get_tlp_type().unwrap(), TlpType::MemWriteReq);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_MEM).get_tlp_type().unwrap(), TlpType::MemWriteReq);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_MEM).get_tlp_type().unwrap(),
+            TlpType::MemReadReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_MEM).get_tlp_type().unwrap(),
+            TlpType::MemReadReq
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_MEM).get_tlp_type().unwrap(),
+            TlpType::MemWriteReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_MEM).get_tlp_type().unwrap(),
+            TlpType::MemWriteReq
+        );
 
         // Memory Lock Request: NoData only (3DW and 4DW)
-        assert_eq!(dw0(FMT_3DW_NO_DATA, TY_MEM_LK).get_tlp_type().unwrap(), TlpType::MemReadLockReq);
-        assert_eq!(dw0(FMT_4DW_NO_DATA, TY_MEM_LK).get_tlp_type().unwrap(), TlpType::MemReadLockReq);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_MEM_LK).get_tlp_type().unwrap(),
+            TlpType::MemReadLockReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_MEM_LK).get_tlp_type().unwrap(),
+            TlpType::MemReadLockReq
+        );
 
         // IO Request: 3DW only; NoData → Read, WithData → Write
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_IO).get_tlp_type().unwrap(), TlpType::IOReadReq);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_IO).get_tlp_type().unwrap(), TlpType::IOWriteReq);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_IO).get_tlp_type().unwrap(),
+            TlpType::IOReadReq
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_IO).get_tlp_type().unwrap(),
+            TlpType::IOWriteReq
+        );
 
         // Config Type 0: 3DW only
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_CFG0).get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_CFG0).get_tlp_type().unwrap(), TlpType::ConfType0WriteReq);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_CFG0).get_tlp_type().unwrap(),
+            TlpType::ConfType0ReadReq
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_CFG0).get_tlp_type().unwrap(),
+            TlpType::ConfType0WriteReq
+        );
 
         // Config Type 1: 3DW only
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_CFG1).get_tlp_type().unwrap(), TlpType::ConfType1ReadReq);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_CFG1).get_tlp_type().unwrap(), TlpType::ConfType1WriteReq);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_CFG1).get_tlp_type().unwrap(),
+            TlpType::ConfType1ReadReq
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_CFG1).get_tlp_type().unwrap(),
+            TlpType::ConfType1WriteReq
+        );
 
         // Completion: 3DW only; NoData → Cpl, WithData → CplData
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_CPL).get_tlp_type().unwrap(), TlpType::Cpl);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_CPL).get_tlp_type().unwrap(), TlpType::CplData);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_CPL).get_tlp_type().unwrap(),
+            TlpType::Cpl
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_CPL).get_tlp_type().unwrap(),
+            TlpType::CplData
+        );
 
         // Completion Locked: 3DW only
-        assert_eq!(dw0(FMT_3DW_NO_DATA,   TY_CPL_LK).get_tlp_type().unwrap(), TlpType::CplLocked);
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_CPL_LK).get_tlp_type().unwrap(), TlpType::CplDataLocked);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_CPL_LK).get_tlp_type().unwrap(),
+            TlpType::CplLocked
+        );
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_CPL_LK).get_tlp_type().unwrap(),
+            TlpType::CplDataLocked
+        );
 
         // Atomics: WithData only (3DW and 4DW)
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_ATOM_FETCH).get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_ATOM_FETCH).get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_ATOM_FETCH)
+                .get_tlp_type()
+                .unwrap(),
+            TlpType::FetchAddAtomicOpReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_ATOM_FETCH)
+                .get_tlp_type()
+                .unwrap(),
+            TlpType::FetchAddAtomicOpReq
+        );
 
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap(), TlpType::SwapAtomicOpReq);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap(), TlpType::SwapAtomicOpReq);
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap(),
+            TlpType::SwapAtomicOpReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap(),
+            TlpType::SwapAtomicOpReq
+        );
 
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_ATOM_CAS).get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_ATOM_CAS).get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_ATOM_CAS).get_tlp_type().unwrap(),
+            TlpType::CompareSwapAtomicOpReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_ATOM_CAS).get_tlp_type().unwrap(),
+            TlpType::CompareSwapAtomicOpReq
+        );
 
         // DMWr: WithData only (3DW and 4DW)
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(),
+            TlpType::DeferrableMemWriteReq
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_DMWR).get_tlp_type().unwrap(),
+            TlpType::DeferrableMemWriteReq
+        );
 
         // Message Requests: all 6 routing sub-types, no-data → MsgReq, with-data → MsgReqData
         // Type[4:0]: 10000=routeRC, 10001=routeAddr, 10010=routeID,
         //            10011=broadcast, 10100=local, 10101=gathered
         for routing in 0b10000u8..=0b10101u8 {
-            assert_eq!(dw0(FMT_3DW_NO_DATA,   routing).get_tlp_type().unwrap(), TlpType::MsgReq,
-                "Fmt=000 Type={:#07b} should be MsgReq", routing);
-            assert_eq!(dw0(FMT_4DW_NO_DATA,   routing).get_tlp_type().unwrap(), TlpType::MsgReq,
-                "Fmt=001 Type={:#07b} should be MsgReq", routing);
-            assert_eq!(dw0(FMT_3DW_WITH_DATA, routing).get_tlp_type().unwrap(), TlpType::MsgReqData,
-                "Fmt=010 Type={:#07b} should be MsgReqData", routing);
-            assert_eq!(dw0(FMT_4DW_WITH_DATA, routing).get_tlp_type().unwrap(), TlpType::MsgReqData,
-                "Fmt=011 Type={:#07b} should be MsgReqData", routing);
+            assert_eq!(
+                dw0(FMT_3DW_NO_DATA, routing).get_tlp_type().unwrap(),
+                TlpType::MsgReq,
+                "Fmt=000 Type={:#07b} should be MsgReq",
+                routing
+            );
+            assert_eq!(
+                dw0(FMT_4DW_NO_DATA, routing).get_tlp_type().unwrap(),
+                TlpType::MsgReq,
+                "Fmt=001 Type={:#07b} should be MsgReq",
+                routing
+            );
+            assert_eq!(
+                dw0(FMT_3DW_WITH_DATA, routing).get_tlp_type().unwrap(),
+                TlpType::MsgReqData,
+                "Fmt=010 Type={:#07b} should be MsgReqData",
+                routing
+            );
+            assert_eq!(
+                dw0(FMT_4DW_WITH_DATA, routing).get_tlp_type().unwrap(),
+                TlpType::MsgReqData,
+                "Fmt=011 Type={:#07b} should be MsgReqData",
+                routing
+            );
         }
-
     }
 
     // ── negative path: every illegal (fmt, type) pair → UnsupportedCombination ─
 
     #[test]
     fn header_decode_rejects_unsupported_combinations() {
-        const FMT_3DW_NO_DATA:   u8 = 0b000;
-        const FMT_4DW_NO_DATA:   u8 = 0b001;
+        const FMT_3DW_NO_DATA: u8 = 0b000;
+        const FMT_4DW_NO_DATA: u8 = 0b001;
         const FMT_3DW_WITH_DATA: u8 = 0b010;
         const FMT_4DW_WITH_DATA: u8 = 0b011;
 
-        const TY_MEM_LK:     u8 = 0b00001;
-        const TY_IO:         u8 = 0b00010;
-        const TY_CFG0:       u8 = 0b00100;
-        const TY_CFG1:       u8 = 0b00101;
-        const TY_CPL:        u8 = 0b01010;
-        const TY_CPL_LK:     u8 = 0b01011;
+        const TY_MEM_LK: u8 = 0b00001;
+        const TY_IO: u8 = 0b00010;
+        const TY_CFG0: u8 = 0b00100;
+        const TY_CFG1: u8 = 0b00101;
+        const TY_CPL: u8 = 0b01010;
+        const TY_CPL_LK: u8 = 0b01011;
         const TY_ATOM_FETCH: u8 = 0b01100;
-        const TY_ATOM_SWAP:  u8 = 0b01101;
-        const TY_ATOM_CAS:   u8 = 0b01110;
-        const TY_DMWR:       u8 = 0b11011;
+        const TY_ATOM_SWAP: u8 = 0b01101;
+        const TY_ATOM_CAS: u8 = 0b01110;
+        const TY_DMWR: u8 = 0b11011;
 
         // IO: 4DW variants are illegal
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_IO).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_IO).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_IO).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_IO).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
 
         // Config: 4DW variants are illegal (configs are always 3DW)
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_CFG0).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_CFG0).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_CFG1).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_CFG1).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_CFG0).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_CFG0).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_CFG1).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_CFG1).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
 
         // Completions: 4DW variants are illegal
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_CPL).get_tlp_type().unwrap_err(),    TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_CPL).get_tlp_type().unwrap_err(),    TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA,   TY_CPL_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_CPL_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_CPL).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_CPL).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_CPL_LK).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_CPL_LK)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
 
         // Atomics: NoData variants are illegal (atomics always carry data)
-        assert_eq!(dw0(FMT_3DW_NO_DATA, TY_ATOM_FETCH).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA, TY_ATOM_FETCH).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_3DW_NO_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap_err(),  TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA, TY_ATOM_SWAP).get_tlp_type().unwrap_err(),  TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_3DW_NO_DATA, TY_ATOM_CAS).get_tlp_type().unwrap_err(),   TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA, TY_ATOM_CAS).get_tlp_type().unwrap_err(),   TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_ATOM_FETCH)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_ATOM_FETCH)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_ATOM_SWAP)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_ATOM_SWAP)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_ATOM_CAS)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_ATOM_CAS)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
 
         // MemReadLock: WithData variants are illegal (lock is a read-only operation)
-        assert_eq!(dw0(FMT_3DW_WITH_DATA, TY_MEM_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_WITH_DATA, TY_MEM_LK).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_3DW_WITH_DATA, TY_MEM_LK)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_WITH_DATA, TY_MEM_LK)
+                .get_tlp_type()
+                .unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
 
         // TlpPrefix fmt (0b100): all Type values decode to a Prefix type, never UnsupportedCombination.
         // These are tested in header_decode_prefix_and_message_types.
 
         // DMWr: NoData variants are illegal (DMWr always carries data)
-        assert_eq!(dw0(FMT_3DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
-        assert_eq!(dw0(FMT_4DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            dw0(FMT_3DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
+        assert_eq!(
+            dw0(FMT_4DW_NO_DATA, TY_DMWR).get_tlp_type().unwrap_err(),
+            TlpError::UnsupportedCombination
+        );
         // Note: FMT_PREFIX with TY_DMWR now decodes to EndToEndTlpPrefix (Type[4]=1)
     }
 
@@ -2006,14 +2303,20 @@ mod tests {
     fn tlp_header_dmwr32_decode() {
         // Fmt=010 (3DW w/ Data), Type=11011 (DMWr) → byte0 = 0x5B
         let dmwr32 = TlpHeader([0x5B, 0x00, 0x00, 0x00]);
-        assert_eq!(dmwr32.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+        assert_eq!(
+            dmwr32.get_tlp_type().unwrap(),
+            TlpType::DeferrableMemWriteReq
+        );
     }
 
     #[test]
     fn tlp_header_dmwr64_decode() {
         // Fmt=011 (4DW w/ Data), Type=11011 (DMWr) → byte0 = 0x7B
         let dmwr64 = TlpHeader([0x7B, 0x00, 0x00, 0x00]);
-        assert_eq!(dmwr64.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+        assert_eq!(
+            dmwr64.get_tlp_type().unwrap(),
+            TlpType::DeferrableMemWriteReq
+        );
     }
 
     #[test]
@@ -2046,7 +2349,7 @@ mod tests {
 
         let mr = new_mem_req(pkt.data().to_vec(), &pkt.tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xABCD);
-        assert_eq!(mr.tag(),    0x42);
+        assert_eq!(mr.tag(), 0x42);
         assert_eq!(mr.address(), 0xDEAD_0000);
     }
 
@@ -2064,7 +2367,7 @@ mod tests {
 
         let mr = new_mem_req(pkt.data().to_vec(), &pkt.tlp_format().unwrap()).unwrap();
         assert_eq!(mr.req_id(), 0xBEEF);
-        assert_eq!(mr.tag(),    0xA5);
+        assert_eq!(mr.tag(), 0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);
     }
 
@@ -2107,33 +2410,90 @@ mod tests {
     #[test]
     fn is_non_posted_exhaustive_all_21_variants() {
         // --- Non-posted (require a Completion) ---
-        assert!(TlpType::MemReadReq.is_non_posted(),          "MemReadReq must be non-posted");
-        assert!(TlpType::MemReadLockReq.is_non_posted(),      "MemReadLockReq must be non-posted");
-        assert!(TlpType::IOReadReq.is_non_posted(),           "IOReadReq must be non-posted");
-        assert!(TlpType::IOWriteReq.is_non_posted(),          "IOWriteReq must be non-posted");
-        assert!(TlpType::ConfType0ReadReq.is_non_posted(),    "ConfType0ReadReq must be non-posted");
-        assert!(TlpType::ConfType0WriteReq.is_non_posted(),   "ConfType0WriteReq must be non-posted");
-        assert!(TlpType::ConfType1ReadReq.is_non_posted(),    "ConfType1ReadReq must be non-posted");
-        assert!(TlpType::ConfType1WriteReq.is_non_posted(),   "ConfType1WriteReq must be non-posted");
-        assert!(TlpType::FetchAddAtomicOpReq.is_non_posted(), "FetchAddAtomicOpReq must be non-posted");
-        assert!(TlpType::SwapAtomicOpReq.is_non_posted(),     "SwapAtomicOpReq must be non-posted");
-        assert!(TlpType::CompareSwapAtomicOpReq.is_non_posted(), "CompareSwapAtomicOpReq must be non-posted");
-        assert!(TlpType::DeferrableMemWriteReq.is_non_posted(), "DeferrableMemWriteReq must be non-posted");
+        assert!(
+            TlpType::MemReadReq.is_non_posted(),
+            "MemReadReq must be non-posted"
+        );
+        assert!(
+            TlpType::MemReadLockReq.is_non_posted(),
+            "MemReadLockReq must be non-posted"
+        );
+        assert!(
+            TlpType::IOReadReq.is_non_posted(),
+            "IOReadReq must be non-posted"
+        );
+        assert!(
+            TlpType::IOWriteReq.is_non_posted(),
+            "IOWriteReq must be non-posted"
+        );
+        assert!(
+            TlpType::ConfType0ReadReq.is_non_posted(),
+            "ConfType0ReadReq must be non-posted"
+        );
+        assert!(
+            TlpType::ConfType0WriteReq.is_non_posted(),
+            "ConfType0WriteReq must be non-posted"
+        );
+        assert!(
+            TlpType::ConfType1ReadReq.is_non_posted(),
+            "ConfType1ReadReq must be non-posted"
+        );
+        assert!(
+            TlpType::ConfType1WriteReq.is_non_posted(),
+            "ConfType1WriteReq must be non-posted"
+        );
+        assert!(
+            TlpType::FetchAddAtomicOpReq.is_non_posted(),
+            "FetchAddAtomicOpReq must be non-posted"
+        );
+        assert!(
+            TlpType::SwapAtomicOpReq.is_non_posted(),
+            "SwapAtomicOpReq must be non-posted"
+        );
+        assert!(
+            TlpType::CompareSwapAtomicOpReq.is_non_posted(),
+            "CompareSwapAtomicOpReq must be non-posted"
+        );
+        assert!(
+            TlpType::DeferrableMemWriteReq.is_non_posted(),
+            "DeferrableMemWriteReq must be non-posted"
+        );
 
         // --- Posted (no Completion expected) ---
-        assert!(!TlpType::MemWriteReq.is_non_posted(),        "MemWriteReq is posted");
-        assert!(!TlpType::MsgReq.is_non_posted(),             "MsgReq is posted");
-        assert!(!TlpType::MsgReqData.is_non_posted(),         "MsgReqData is posted");
+        assert!(
+            !TlpType::MemWriteReq.is_non_posted(),
+            "MemWriteReq is posted"
+        );
+        assert!(!TlpType::MsgReq.is_non_posted(), "MsgReq is posted");
+        assert!(!TlpType::MsgReqData.is_non_posted(), "MsgReqData is posted");
 
         // --- Completions (responses, not requests) ---
-        assert!(!TlpType::Cpl.is_non_posted(),                "Cpl is a response, not a request");
-        assert!(!TlpType::CplData.is_non_posted(),            "CplData is a response, not a request");
-        assert!(!TlpType::CplLocked.is_non_posted(),          "CplLocked is a response, not a request");
-        assert!(!TlpType::CplDataLocked.is_non_posted(),      "CplDataLocked is a response, not a request");
+        assert!(
+            !TlpType::Cpl.is_non_posted(),
+            "Cpl is a response, not a request"
+        );
+        assert!(
+            !TlpType::CplData.is_non_posted(),
+            "CplData is a response, not a request"
+        );
+        assert!(
+            !TlpType::CplLocked.is_non_posted(),
+            "CplLocked is a response, not a request"
+        );
+        assert!(
+            !TlpType::CplDataLocked.is_non_posted(),
+            "CplDataLocked is a response, not a request"
+        );
 
         // --- Prefixes (not transactions) ---
-        assert!(!TlpType::LocalTlpPrefix.is_non_posted(),     "LocalTlpPrefix is not a transaction");
-        assert!(!TlpType::EndToEndTlpPrefix.is_non_posted(),  "EndToEndTlpPrefix is not a transaction");
+        assert!(
+            !TlpType::LocalTlpPrefix.is_non_posted(),
+            "LocalTlpPrefix is not a transaction"
+        );
+        assert!(
+            !TlpType::EndToEndTlpPrefix.is_non_posted(),
+            "EndToEndTlpPrefix is not a transaction"
+        );
     }
 
     // ── atomic tier-A: real bytes through the full packet pipeline ─────────────
@@ -2141,7 +2501,7 @@ mod tests {
     #[test]
     fn atomic_fetchadd_3dw_type_and_fields() {
         const FMT_3DW_WITH_DATA: u8 = 0b010;
-        const TY_ATOM_FETCH:     u8 = 0b01100;
+        const TY_ATOM_FETCH: u8 = 0b01100;
 
         // DW1+DW2 as MemRequest3DW sees them (MSB0):
         //   requester_id [15:0]  = 0x1234
@@ -2155,22 +2515,26 @@ mod tests {
             0x89, 0xAB, 0xCD, 0xEF, // address32
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload), TlpMode::NonFlit).unwrap();
+        let pkt = TlpPacket::new(
+            mk_tlp(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &payload),
+            TlpMode::NonFlit,
+        )
+        .unwrap();
 
         assert_eq!(pkt.tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
         assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 
         let fmt = pkt.tlp_format().unwrap();
         let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
-        assert_eq!(mr.req_id(),  0x1234);
-        assert_eq!(mr.tag(),     0x56);
+        assert_eq!(mr.req_id(), 0x1234);
+        assert_eq!(mr.tag(), 0x56);
         assert_eq!(mr.address(), 0x89AB_CDEF);
     }
 
     #[test]
     fn atomic_cas_4dw_type_and_fields() {
         const FMT_4DW_WITH_DATA: u8 = 0b011;
-        const TY_ATOM_CAS:       u8 = 0b01110;
+        const TY_ATOM_CAS: u8 = 0b01110;
 
         // DW1-DW3 as MemRequest4DW sees them (MSB0):
         //   requester_id [15:0]  = 0xBEEF
@@ -2184,15 +2548,19 @@ mod tests {
             0x55, 0x66, 0x77, 0x88, // address64 low DW
         ];
 
-        let pkt = TlpPacket::new(mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload), TlpMode::NonFlit).unwrap();
+        let pkt = TlpPacket::new(
+            mk_tlp(FMT_4DW_WITH_DATA, TY_ATOM_CAS, &payload),
+            TlpMode::NonFlit,
+        )
+        .unwrap();
 
         assert_eq!(pkt.tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
         assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 
         let fmt = pkt.tlp_format().unwrap();
         let mr = new_mem_req(pkt.data().to_vec(), &fmt).unwrap();
-        assert_eq!(mr.req_id(),  0xBEEF);
-        assert_eq!(mr.tag(),     0xA5);
+        assert_eq!(mr.req_id(), 0xBEEF);
+        assert_eq!(mr.tag(), 0xA5);
         assert_eq!(mr.address(), 0x1122_3344_5566_7788);
     }
 
@@ -2210,13 +2578,13 @@ mod tests {
             0x00, 0x00, 0x00, 0x0A, // addend (W32)
         ];
         let pkt = TlpPacket::new(mk_tlp(0b010, 0b01100, &payload), TlpMode::NonFlit).unwrap();
-        let ar  = new_atomic_req(&pkt).unwrap();
+        let ar = new_atomic_req(&pkt).unwrap();
 
-        assert_eq!(ar.op(),       AtomicOp::FetchAdd);
-        assert_eq!(ar.width(),    AtomicWidth::W32);
-        assert_eq!(ar.req_id(),   0xDEAD);
-        assert_eq!(ar.tag(),      0x42);
-        assert_eq!(ar.address(),  0xC001_0004);
+        assert_eq!(ar.op(), AtomicOp::FetchAdd);
+        assert_eq!(ar.width(), AtomicWidth::W32);
+        assert_eq!(ar.req_id(), 0xDEAD);
+        assert_eq!(ar.tag(), 0x42);
+        assert_eq!(ar.address(), 0xC001_0004);
         assert_eq!(ar.operand0(), 0x0A);
         assert!(ar.operand1().is_none());
     }
@@ -2233,13 +2601,13 @@ mod tests {
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // addend (W64)
         ];
         let pkt = TlpPacket::new(mk_tlp(0b011, 0b01100, &payload), TlpMode::NonFlit).unwrap();
-        let ar  = new_atomic_req(&pkt).unwrap();
+        let ar = new_atomic_req(&pkt).unwrap();
 
-        assert_eq!(ar.op(),       AtomicOp::FetchAdd);
-        assert_eq!(ar.width(),    AtomicWidth::W64);
-        assert_eq!(ar.req_id(),   0x0042);
-        assert_eq!(ar.tag(),      0xBB);
-        assert_eq!(ar.address(),  0x0000_0001_0000_0000);
+        assert_eq!(ar.op(), AtomicOp::FetchAdd);
+        assert_eq!(ar.width(), AtomicWidth::W64);
+        assert_eq!(ar.req_id(), 0x0042);
+        assert_eq!(ar.tag(), 0xBB);
+        assert_eq!(ar.address(), 0x0000_0001_0000_0000);
         assert_eq!(ar.operand0(), 0xFFFF_FFFF_FFFF_FFFF);
         assert!(ar.operand1().is_none());
     }
@@ -2256,13 +2624,13 @@ mod tests {
             0xAB, 0xCD, 0xEF, 0x01, // new_value (W32)
         ];
         let pkt = TlpPacket::new(mk_tlp(0b010, 0b01101, &payload), TlpMode::NonFlit).unwrap();
-        let ar  = new_atomic_req(&pkt).unwrap();
+        let ar = new_atomic_req(&pkt).unwrap();
 
-        assert_eq!(ar.op(),       AtomicOp::Swap);
-        assert_eq!(ar.width(),    AtomicWidth::W32);
-        assert_eq!(ar.req_id(),   0x1111);
-        assert_eq!(ar.tag(),      0x05);
-        assert_eq!(ar.address(),  0xF000_0008);
+        assert_eq!(ar.op(), AtomicOp::Swap);
+        assert_eq!(ar.width(), AtomicWidth::W32);
+        assert_eq!(ar.req_id(), 0x1111);
+        assert_eq!(ar.tag(), 0x05);
+        assert_eq!(ar.address(), 0xF000_0008);
         assert_eq!(ar.operand0(), 0xABCD_EF01);
         assert!(ar.operand1().is_none());
     }
@@ -2281,13 +2649,13 @@ mod tests {
             0xDE, 0xAD, 0xBE, 0xEF, // swap    (W32)
         ];
         let pkt = TlpPacket::new(mk_tlp(0b010, 0b01110, &payload), TlpMode::NonFlit).unwrap();
-        let ar  = new_atomic_req(&pkt).unwrap();
+        let ar = new_atomic_req(&pkt).unwrap();
 
-        assert_eq!(ar.op(),       AtomicOp::CompareSwap);
-        assert_eq!(ar.width(),    AtomicWidth::W32);
-        assert_eq!(ar.req_id(),   0xABCD);
-        assert_eq!(ar.tag(),      0x07);
-        assert_eq!(ar.address(),  0x0000_4000);
+        assert_eq!(ar.op(), AtomicOp::CompareSwap);
+        assert_eq!(ar.width(), AtomicWidth::W32);
+        assert_eq!(ar.req_id(), 0xABCD);
+        assert_eq!(ar.tag(), 0x07);
+        assert_eq!(ar.address(), 0x0000_4000);
         assert_eq!(ar.operand0(), 0xCAFE_BABE);
         assert_eq!(ar.operand1(), Some(0xDEAD_BEEF));
     }
@@ -2306,13 +2674,13 @@ mod tests {
             0x03, 0x03, 0x03, 0x03, 0x04, 0x04, 0x04, 0x04, // swap    (W64)
         ];
         let pkt = TlpPacket::new(mk_tlp(0b011, 0b01110, &payload), TlpMode::NonFlit).unwrap();
-        let ar  = new_atomic_req(&pkt).unwrap();
+        let ar = new_atomic_req(&pkt).unwrap();
 
-        assert_eq!(ar.op(),       AtomicOp::CompareSwap);
-        assert_eq!(ar.width(),    AtomicWidth::W64);
-        assert_eq!(ar.req_id(),   0x1234);
-        assert_eq!(ar.tag(),      0xAA);
-        assert_eq!(ar.address(),  0xFFFF_FFFF_0000_0000);
+        assert_eq!(ar.op(), AtomicOp::CompareSwap);
+        assert_eq!(ar.width(), AtomicWidth::W64);
+        assert_eq!(ar.req_id(), 0x1234);
+        assert_eq!(ar.tag(), 0xAA);
+        assert_eq!(ar.address(), 0xFFFF_FFFF_0000_0000);
         assert_eq!(ar.operand0(), 0x0101_0101_0202_0202);
         assert_eq!(ar.operand1(), Some(0x0303_0303_0404_0404));
     }
@@ -2321,7 +2689,10 @@ mod tests {
     fn atomic_req_rejects_wrong_tlp_type() {
         // MemRead type is not an atomic — should get UnsupportedCombination
         let pkt = TlpPacket::new(mk_tlp(0b000, 0b00000, &[0u8; 16]), TlpMode::NonFlit).unwrap();
-        assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            new_atomic_req(&pkt).err().unwrap(),
+            TlpError::UnsupportedCombination
+        );
     }
 
     #[test]
@@ -2329,7 +2700,10 @@ mod tests {
         // FetchAdd type with NoData3DW format is an invalid combo:
         // get_tlp_type() returns UnsupportedCombination, which propagates
         let pkt = TlpPacket::new(mk_tlp(0b000, 0b01100, &[0u8; 16]), TlpMode::NonFlit).unwrap();
-        assert_eq!(new_atomic_req(&pkt).err().unwrap(), TlpError::UnsupportedCombination);
+        assert_eq!(
+            new_atomic_req(&pkt).err().unwrap(),
+            TlpError::UnsupportedCombination
+        );
     }
 
     #[test]
@@ -2365,11 +2739,11 @@ mod tests {
         ];
         let pkt = mk_pkt(0b010, 0b01100, &data);
         let a = new_atomic_req(&pkt).unwrap();
-        assert_eq!(a.op(),       AtomicOp::FetchAdd);
-        assert_eq!(a.width(),    AtomicWidth::W32);
-        assert_eq!(a.req_id(),   0x0100);
-        assert_eq!(a.tag(),      0x01);
-        assert_eq!(a.address(),  0x0000_1000);
+        assert_eq!(a.op(), AtomicOp::FetchAdd);
+        assert_eq!(a.width(), AtomicWidth::W32);
+        assert_eq!(a.req_id(), 0x0100);
+        assert_eq!(a.tag(), 0x01);
+        assert_eq!(a.address(), 0x0000_1000);
         assert_eq!(a.operand0(), 7);
         assert!(a.operand1().is_none());
     }
@@ -2384,11 +2758,11 @@ mod tests {
         ];
         let pkt = mk_pkt(0b011, 0b01101, &data);
         let a = new_atomic_req(&pkt).unwrap();
-        assert_eq!(a.op(),       AtomicOp::Swap);
-        assert_eq!(a.width(),    AtomicWidth::W64);
-        assert_eq!(a.req_id(),   0xBEEF);
-        assert_eq!(a.tag(),      0xA5);
-        assert_eq!(a.address(),  0x0000_0001_0000_0000);
+        assert_eq!(a.op(), AtomicOp::Swap);
+        assert_eq!(a.width(), AtomicWidth::W64);
+        assert_eq!(a.req_id(), 0xBEEF);
+        assert_eq!(a.tag(), 0xA5);
+        assert_eq!(a.address(), 0x0000_0001_0000_0000);
         assert_eq!(a.operand0(), 0xDEAD_BEEF_CAFE_BABE);
         assert!(a.operand1().is_none());
     }
@@ -2404,11 +2778,11 @@ mod tests {
         ];
         let pkt = mk_pkt(0b010, 0b01110, &data);
         let a = new_atomic_req(&pkt).unwrap();
-        assert_eq!(a.op(),       AtomicOp::CompareSwap);
-        assert_eq!(a.width(),    AtomicWidth::W32);
-        assert_eq!(a.req_id(),   0xABCD);
-        assert_eq!(a.tag(),      0x07);
-        assert_eq!(a.address(),  0x0000_4000);
+        assert_eq!(a.op(), AtomicOp::CompareSwap);
+        assert_eq!(a.width(), AtomicWidth::W32);
+        assert_eq!(a.req_id(), 0xABCD);
+        assert_eq!(a.tag(), 0x07);
+        assert_eq!(a.address(), 0x0000_4000);
         assert_eq!(a.operand0(), 0xCAFE_BABE);
         assert_eq!(a.operand1(), Some(0xDEAD_BEEF));
     }
@@ -2431,10 +2805,7 @@ mod tests {
     fn completion_laddr_bit6_set() {
         // Lower Address = 64 (0x40) — bit 6 is the bit that was previously lost
         // DW2 byte 3: R=0, LowerAddr=0x40 → byte = 0x40
-        let bytes = vec![
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x40,
-        ];
+        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40];
         let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.laddr(), 0x40);
     }
@@ -2443,10 +2814,7 @@ mod tests {
     fn completion_laddr_with_reserved_bit_set() {
         // R=1, LowerAddr=0x55 (85)
         // DW2 byte 3: 1_1010101 = 0xD5
-        let bytes = vec![
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0xD5,
-        ];
+        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xD5];
         let cmpl = new_cmpl_req(bytes);
         assert_eq!(cmpl.laddr(), 0x55);
     }
@@ -2510,9 +2878,7 @@ mod tests {
     fn message_dw3_dw4_all_bits_set() {
         // Both DW3 and DW4 = 0xFFFF_FFFF
         let bytes = vec![
-            0x00, 0x00, 0x00, 0x00,
-            0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
+            0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         ];
         let msg = new_msg_req(bytes);
         assert_eq!(msg.dw3(), 0xFFFF_FFFF);
@@ -2523,16 +2889,14 @@ mod tests {
     fn message_request_full_fields() {
         // req_id=0xABCD, tag=0x42, msg_code=0x7F, DW3=0x1234_5678, DW4=0x9ABC_DEF0
         let bytes = vec![
-            0xAB, 0xCD, 0x42, 0x7F,
-            0x12, 0x34, 0x56, 0x78,
-            0x9A, 0xBC, 0xDE, 0xF0,
+            0xAB, 0xCD, 0x42, 0x7F, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
         ];
         let msg = new_msg_req(bytes);
-        assert_eq!(msg.req_id(),   0xABCD);
-        assert_eq!(msg.tag(),      0x42);
+        assert_eq!(msg.req_id(), 0xABCD);
+        assert_eq!(msg.tag(), 0x42);
         assert_eq!(msg.msg_code(), 0x7F);
-        assert_eq!(msg.dw3(),      0x1234_5678);
-        assert_eq!(msg.dw4(),      0x9ABC_DEF0);
+        assert_eq!(msg.dw3(), 0x1234_5678);
+        assert_eq!(msg.dw4(), 0x9ABC_DEF0);
     }
 
     // ── Debug impls ───────────────────────────────────────────────────────────
@@ -2548,7 +2912,8 @@ mod tests {
 
     #[test]
     fn tlp_packet_debug() {
-        let pkt = TlpPacket::new(vec![0x40, 0x00, 0x00, 0x01, 0xDE, 0xAD], TlpMode::NonFlit).unwrap();
+        let pkt =
+            TlpPacket::new(vec![0x40, 0x00, 0x00, 0x01, 0xDE, 0xAD], TlpMode::NonFlit).unwrap();
         let s = format!("{:?}", pkt);
         assert!(s.contains("TlpPacket"));
         assert!(s.contains("data_len"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1430,10 +1430,18 @@ mod tests {
     #[test]
     fn test_invalid_format_error() {
         // Format field with invalid value (e.g., 0b101 = 5)
-        let invalid_fmt = TlpHeader([0xa0, 0x00, 0x00, 0x01]); // FMT='101' Type='00000'
-        let result = invalid_fmt.get_tlp_type();
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), TlpError::InvalidFormat);
+        // byte0 layout: bits[7:5] = fmt, bits[4:0] = type
+        // Fmt=0b101 → byte0 = 0b1010_0000 = 0xA0
+        let invalid_fmt_101 = TlpHeader([0xa0, 0x00, 0x00, 0x01]);
+        assert_eq!(invalid_fmt_101.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
+
+        // Fmt=0b110 → byte0 = 0b1100_0000 = 0xC0
+        let invalid_fmt_110 = TlpHeader([0xc0, 0x00, 0x00, 0x01]);
+        assert_eq!(invalid_fmt_110.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
+
+        // Fmt=0b111 → byte0 = 0b1110_0000 = 0xE0
+        let invalid_fmt_111 = TlpHeader([0xe0, 0x00, 0x00, 0x01]);
+        assert_eq!(invalid_fmt_111.get_tlp_type().unwrap_err(), TlpError::InvalidFormat);
     }
 
     #[test]

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -107,7 +107,7 @@ fn tlp_mode_flit_packet_new_succeeds() {
     let bytes = vec![0x00u8; 4];
     let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
-    assert!(pkt.get_data().is_empty());
+    assert!(pkt.data().is_empty());
 }
 
 #[test]
@@ -269,12 +269,24 @@ fn tlp_packet_get_tlp_format_exists() {
     assert!(format.is_ok());
 }
 
+/// API contract test: `get_data()` is deprecated but must continue to work
+/// until it is fully removed in a future semver break.
+/// See also `tlp_packet_data_method_exists` for the new non-allocating form.
 #[test]
+#[allow(deprecated)]
 fn tlp_packet_get_data_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC, 0xDD];
     let packet = TlpPacket::new(data.clone(), TlpMode::NonFlit).unwrap();
-    let returned_data = packet.get_data();
+    let returned_data = packet.get_data(); // deprecated — tests backward compat
     assert_eq!(returned_data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
+}
+
+#[test]
+fn tlp_packet_data_method_exists() {
+    // Preferred non-allocating form: data() returns &[u8]
+    let data = vec![0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC, 0xDD];
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
+    assert_eq!(packet.data(), [0xAA, 0xBB, 0xCC, 0xDD]);
 }
 
 // ============================================================================
@@ -718,14 +730,14 @@ fn tlp_packet_handles_minimum_size() {
 fn tlp_packet_handles_empty_data_section() {
     let data = vec![0x00, 0x00, 0x00, 0x01];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(packet.get_data(), Vec::<u8>::new());
+    assert!(packet.data().is_empty());
 }
 
 #[test]
 fn tlp_packet_preserves_data_payload() {
-    let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let payload = [0xDE, 0xAD, 0xBE, 0xEF];
     let mut data = vec![0x00, 0x00, 0x00, 0x01];
     data.extend_from_slice(&payload);
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(packet.get_data(), payload);
+    assert_eq!(packet.data(), payload);
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -17,6 +17,7 @@ fn error_type_exists_and_is_public() {
     let _err3: TlpError = TlpError::UnsupportedCombination;
     let _err4: TlpError = TlpError::InvalidLength;
     let _err5: TlpError = TlpError::NotImplemented;
+    let _err6: TlpError = TlpError::MissingMandatoryOhc;
 }
 
 #[test]
@@ -541,8 +542,8 @@ fn api_all_expected_public_types_are_available() {
         CompletionReqDW23, MessageReqDW24,
         AtomicOp, AtomicWidth,
         new_mem_req, new_conf_req, new_cmpl_req, new_msg_req, new_atomic_req,
-        // Flit mode types (Tier 1+2)
-        FlitTlpType, FlitDW0,
+        // Flit mode types (Tier 1+2+3)
+        FlitTlpType, FlitDW0, FlitOhcA,
     };
     
     // Use types to prevent unused warnings
@@ -572,6 +573,47 @@ fn api_all_expected_public_types_are_available() {
     // Flit mode public API — will fail to compile if removed or renamed
     let _: Option<FlitTlpType> = None;
     let _: Option<FlitDW0> = None;
+    let _: Option<FlitOhcA> = None;
+}
+
+#[test]
+fn flit_ohc_a_struct_is_public_and_constructible() {
+    // OHC-A word [0x01, 0x23, 0x45, 0x0F]: PASID=0x12345, fdwbe=0xF, ldwbe=0x0
+    let ohc = FlitOhcA::from_bytes(&[0x01, 0x23, 0x45, 0x0F]).unwrap();
+    let _: u32 = ohc.pasid;
+    let _: u8  = ohc.fdwbe;
+    let _: u8  = ohc.ldwbe;
+    assert_eq!(ohc.pasid, 0x12345);
+    assert_eq!(ohc.fdwbe, 0xF);
+    assert_eq!(ohc.ldwbe, 0x0);
+}
+
+#[test]
+fn flit_ohc_a_short_slice_returns_invalid_length() {
+    assert_eq!(
+        FlitOhcA::from_bytes(&[0x00, 0x00, 0x00]).err().unwrap(),
+        TlpError::InvalidLength
+    );
+}
+
+#[test]
+fn flit_missing_mandatory_ohc_error_is_distinct() {
+    let e = TlpError::MissingMandatoryOhc;
+    assert_eq!(e, TlpError::MissingMandatoryOhc);
+    assert_ne!(e, TlpError::NotImplemented);
+    assert_ne!(e, TlpError::InvalidType);
+    let s = format!("{:?}", e);
+    assert!(s.contains("MissingMandatoryOhc"));
+}
+
+#[test]
+fn flit_validate_mandatory_ohc_non_mandatory_types_always_pass() {
+    // Non-mandatory types succeed even without OHC
+    let nop_dw0 = FlitDW0::from_dw0(&[0x00, 0x00, 0x00, 0x00]).unwrap(); // Nop, ohc=0
+    assert!(nop_dw0.validate_mandatory_ohc().is_ok());
+
+    let mwr_dw0 = FlitDW0::from_dw0(&[0x40, 0x00, 0x00, 0x01]).unwrap(); // MemWrite32, ohc=0
+    assert!(mwr_dw0.validate_mandatory_ohc().is_ok());
 }
 
 // ============================================================================

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -541,6 +541,8 @@ fn api_all_expected_public_types_are_available() {
         CompletionReqDW23, MessageReqDW24,
         AtomicOp, AtomicWidth,
         new_mem_req, new_conf_req, new_cmpl_req, new_msg_req, new_atomic_req,
+        // Flit mode types (Tier 1+2)
+        FlitTlpType, FlitDW0,
     };
     
     // Use types to prevent unused warnings
@@ -566,6 +568,67 @@ fn api_all_expected_public_types_are_available() {
     let _ = new_atomic_req;
     let _: Option<AtomicOp> = None;
     let _: Option<AtomicWidth> = None;
+
+    // Flit mode public API — will fail to compile if removed or renamed
+    let _: Option<FlitTlpType> = None;
+    let _: Option<FlitDW0> = None;
+}
+
+// ============================================================================
+// FlitTlpType API Tests
+// ============================================================================
+
+#[test]
+fn flit_tlp_type_enum_has_expected_variants() {
+    let _: FlitTlpType = FlitTlpType::Nop;
+    let _: FlitTlpType = FlitTlpType::MemRead32;
+    let _: FlitTlpType = FlitTlpType::UioMemRead;
+    let _: FlitTlpType = FlitTlpType::MsgToRc;
+    let _: FlitTlpType = FlitTlpType::MemWrite32;
+    let _: FlitTlpType = FlitTlpType::IoWrite;
+    let _: FlitTlpType = FlitTlpType::CfgWrite0;
+    let _: FlitTlpType = FlitTlpType::FetchAdd32;
+    let _: FlitTlpType = FlitTlpType::CompareSwap32;
+    let _: FlitTlpType = FlitTlpType::DeferrableMemWrite32;
+    let _: FlitTlpType = FlitTlpType::UioMemWrite;
+    let _: FlitTlpType = FlitTlpType::MsgDToRc;
+    let _: FlitTlpType = FlitTlpType::LocalTlpPrefix;
+}
+
+#[test]
+fn flit_tlp_type_implements_debug_and_partialeq() {
+    assert_eq!(FlitTlpType::Nop, FlitTlpType::Nop);
+    assert_ne!(FlitTlpType::Nop, FlitTlpType::MemRead32);
+    let s = format!("{:?}", FlitTlpType::MemRead32);
+    assert!(s.contains("MemRead32"));
+}
+
+#[test]
+fn flit_tlp_type_try_from_u8_valid_type_codes() {
+    assert!(FlitTlpType::try_from(0x00u8).is_ok()); // Nop
+    assert!(FlitTlpType::try_from(0x03u8).is_ok()); // MemRead32
+    assert!(FlitTlpType::try_from(0x40u8).is_ok()); // MemWrite32
+    assert!(FlitTlpType::try_from(0x4Eu8).is_ok()); // CompareSwap32
+    assert!(FlitTlpType::try_from(0x8Du8).is_ok()); // LocalTlpPrefix
+}
+
+#[test]
+fn flit_tlp_type_try_from_u8_unknown_returns_invalid_type() {
+    assert_eq!(FlitTlpType::try_from(0xFFu8).err().unwrap(), TlpError::InvalidType);
+    assert_eq!(FlitTlpType::try_from(0x01u8).err().unwrap(), TlpError::InvalidType);
+}
+
+#[test]
+fn flit_dw0_struct_is_public_and_constructible() {
+    let dw0 = FlitDW0::from_dw0(&[0x00, 0x00, 0x00, 0x00]).unwrap();
+    let _: FlitTlpType = dw0.tlp_type;
+    let _: u8  = dw0.tc;
+    let _: u8  = dw0.ohc;
+    let _: u8  = dw0.ts;
+    let _: u8  = dw0.attr;
+    let _: u16 = dw0.length;
+    let _: u8  = dw0.ohc_count();
+    let _: usize = dw0.total_bytes();
 }
 
 // ============================================================================

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -34,6 +34,35 @@ fn error_type_implements_partialeq() {
 }
 
 #[test]
+fn error_type_implements_display() {
+    // Verify all variants produce non-empty human-readable messages
+    let variants = [
+        TlpError::InvalidFormat,
+        TlpError::InvalidType,
+        TlpError::UnsupportedCombination,
+        TlpError::InvalidLength,
+        TlpError::NotImplemented,
+        TlpError::MissingMandatoryOhc,
+    ];
+    for e in &variants {
+        let s = format!("{e}");
+        assert!(!s.is_empty(), "Display for {e:?} must not be empty");
+    }
+}
+
+#[test]
+fn error_type_implements_std_error() {
+    // TlpError must be usable as Box<dyn std::error::Error>
+    fn returns_box_error() -> Result<(), Box<dyn std::error::Error>> {
+        let _ = TlpPacket::new(vec![], TlpMode::NonFlit)?;
+        Ok(())
+    }
+    let err = returns_box_error().unwrap_err();
+    // The Display message should be meaningful
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
 fn error_not_implemented_exists_and_is_distinct() {
     let e = TlpError::NotImplemented;
     assert_eq!(e, TlpError::NotImplemented);

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -450,7 +450,6 @@ fn new_mem_req_factory_exists() {
 #[test]
 fn new_conf_req_factory_exists() {
     let bytes = vec![0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let format = TlpFmt::NoDataHeader3DW;
     let result = new_conf_req(bytes);
     // Factory returns Box<dyn ConfigurationRequest>, verify it has the expected methods
     let _req_id = result.req_id();
@@ -460,7 +459,6 @@ fn new_conf_req_factory_exists() {
 #[test]
 fn new_cmpl_req_factory_exists() {
     let bytes = vec![0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let format = TlpFmt::NoDataHeader3DW;
     let result = new_cmpl_req(bytes);
     // Factory returns Box<dyn CompletionRequest>, verify it has the expected methods
     let _req_id = result.req_id();

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -1,8 +1,7 @@
 /// API Contract Tests
-/// 
+///
 /// These tests verify the public API surface and contracts.
 /// They should catch any breaking changes to the library's interface.
-
 use rtlp_lib::*;
 
 // ============================================================================
@@ -85,12 +84,13 @@ fn tlp_mode_enum_has_expected_variants() {
 }
 
 #[test]
+#[allow(clippy::clone_on_copy)]
 fn tlp_mode_implements_debug_clone_copy_partialeq() {
     assert_eq!(TlpMode::NonFlit, TlpMode::NonFlit);
     assert_ne!(TlpMode::NonFlit, TlpMode::Flit);
 
     let m = TlpMode::NonFlit;
-    let m2 = m;        // Copy
+    let m2 = m; // Copy
     let m3 = m.clone(); // Clone
     assert_eq!(m2, TlpMode::NonFlit);
     assert_eq!(m3, TlpMode::NonFlit);
@@ -114,7 +114,10 @@ fn tlp_mode_flit_packet_new_succeeds() {
 fn tlp_mode_flit_returns_not_implemented_for_header() {
     // TlpPacketHeader::new() with Flit still returns NotImplemented
     let bytes = vec![0x00u8; 4];
-    assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+    assert_eq!(
+        TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(),
+        TlpError::NotImplemented
+    );
 }
 
 // ============================================================================
@@ -157,35 +160,35 @@ fn tlp_type_enum_has_all_expected_variants() {
     let _t1: TlpType = TlpType::MemReadReq;
     let _t2: TlpType = TlpType::MemReadLockReq;
     let _t3: TlpType = TlpType::MemWriteReq;
-    
+
     // IO requests
     let _t4: TlpType = TlpType::IOReadReq;
     let _t5: TlpType = TlpType::IOWriteReq;
-    
+
     // Configuration requests
     let _t6: TlpType = TlpType::ConfType0ReadReq;
     let _t7: TlpType = TlpType::ConfType0WriteReq;
     let _t8: TlpType = TlpType::ConfType1ReadReq;
     let _t9: TlpType = TlpType::ConfType1WriteReq;
-    
+
     // Messages
     let _t10: TlpType = TlpType::MsgReq;
     let _t11: TlpType = TlpType::MsgReqData;
-    
+
     // Completions
     let _t12: TlpType = TlpType::Cpl;
     let _t13: TlpType = TlpType::CplData;
     let _t14: TlpType = TlpType::CplLocked;
     let _t15: TlpType = TlpType::CplDataLocked;
-    
+
     // Atomic operations
     let _t16: TlpType = TlpType::FetchAddAtomicOpReq;
     let _t17: TlpType = TlpType::SwapAtomicOpReq;
     let _t18: TlpType = TlpType::CompareSwapAtomicOpReq;
-    
+
     // Deferrable Memory Write
     let _t19: TlpType = TlpType::DeferrableMemWriteReq;
-    
+
     // Prefixes
     let _t20: TlpType = TlpType::LocalTlpPrefix;
     let _t21: TlpType = TlpType::EndToEndTlpPrefix;
@@ -344,7 +347,9 @@ fn memrequest_3dw_trait_methods_return_expected_types() {
 
 #[test]
 fn memrequest_4dw_trait_methods_return_expected_types() {
-    let mr = MemRequest4DW([0x00, 0x00, 0x20, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
+    let mr = MemRequest4DW([
+        0x00, 0x00, 0x20, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
     let _req_id: u16 = mr.req_id();
     let _tag: u8 = mr.tag();
     let _last_be: u8 = mr.ldwbe();
@@ -424,7 +429,9 @@ fn completion_request_trait_methods_return_expected_types() {
 
 #[test]
 fn message_request_trait_exists() {
-    let msg = MessageReqDW24([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]);
+    let msg = MessageReqDW24([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    ]);
     let _req_id = msg.req_id();
     let _msg_code = msg.msg_code();
     let _tag = msg.tag();
@@ -437,7 +444,9 @@ fn message_request_struct_is_public() {
 
 #[test]
 fn message_request_trait_methods_return_expected_types() {
-    let msg = MessageReqDW24([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]);
+    let msg = MessageReqDW24([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    ]);
     let _req_id: u16 = msg.req_id();
     let _msg_code: u8 = msg.msg_code();
     let _tag: u8 = msg.tag();
@@ -479,7 +488,9 @@ fn new_cmpl_req_factory_exists() {
 
 #[test]
 fn new_msg_req_factory_exists() {
-    let bytes = vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let bytes = vec![
+        0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
     let result = new_msg_req(bytes);
     // Factory returns Box<dyn MessageRequest>, verify it has the expected methods
     let _req_id = result.req_id();
@@ -496,13 +507,13 @@ fn new_atomic_req_factory_exists() {
     let result = new_atomic_req(&pkt);
     assert!(result.is_ok());
     let ar = result.unwrap();
-    let _op    = ar.op();
+    let _op = ar.op();
     let _width = ar.width();
-    let _rid   = ar.req_id();
-    let _tag   = ar.tag();
-    let _addr  = ar.address();
-    let _op0   = ar.operand0();
-    let _op1   = ar.operand1();
+    let _rid = ar.req_id();
+    let _tag = ar.tag();
+    let _addr = ar.address();
+    let _op0 = ar.operand0();
+    let _op1 = ar.operand1();
 }
 
 // ============================================================================
@@ -578,16 +589,30 @@ fn atomic_req_returns_err_for_short_payload() {
 fn api_all_expected_public_types_are_available() {
     // This test will fail to compile if any public type is removed or renamed
     use rtlp_lib::{
-        TlpError, TlpFmt, TlpType, TlpMode,
-        TlpPacket, TlpPacketHeader,
-        MemRequest3DW, MemRequest4DW, ConfigRequest,
-        CompletionReqDW23, MessageReqDW24,
-        AtomicOp, AtomicWidth,
-        new_mem_req, new_conf_req, new_cmpl_req, new_msg_req, new_atomic_req,
+        AtomicOp,
+        AtomicWidth,
+        CompletionReqDW23,
+        ConfigRequest,
+        FlitDW0,
+        FlitOhcA,
         // Flit mode types (Tier 1+2+3)
-        FlitTlpType, FlitDW0, FlitOhcA,
+        FlitTlpType,
+        MemRequest3DW,
+        MemRequest4DW,
+        MessageReqDW24,
+        TlpError,
+        TlpFmt,
+        TlpMode,
+        TlpPacket,
+        TlpPacketHeader,
+        TlpType,
+        new_atomic_req,
+        new_cmpl_req,
+        new_conf_req,
+        new_mem_req,
+        new_msg_req,
     };
-    
+
     // Use types to prevent unused warnings
     let _: Option<TlpError> = None;
     let _: Option<TlpFmt> = None;
@@ -601,7 +626,7 @@ fn api_all_expected_public_types_are_available() {
     let _: Option<ConfigRequest<[u8; 8]>> = None;
     let _: Option<CompletionReqDW23<[u8; 8]>> = None;
     let _: Option<MessageReqDW24<[u8; 12]>> = None;
-    
+
     // All four factory functions accept impl Into<Vec<u8>>.
     // Calling with an empty Vec<u8> satisfies inference and proves importability.
     let _ = new_mem_req(vec![0u8; 0], &TlpFmt::NoDataHeader3DW);
@@ -623,8 +648,8 @@ fn flit_ohc_a_struct_is_public_and_constructible() {
     // OHC-A word [0x01, 0x23, 0x45, 0x0F]: PASID=0x12345, fdwbe=0xF, ldwbe=0x0
     let ohc = FlitOhcA::from_bytes(&[0x01, 0x23, 0x45, 0x0F]).unwrap();
     let _: u32 = ohc.pasid;
-    let _: u8  = ohc.fdwbe;
-    let _: u8  = ohc.ldwbe;
+    let _: u8 = ohc.fdwbe;
+    let _: u8 = ohc.ldwbe;
     assert_eq!(ohc.pasid, 0x12345);
     assert_eq!(ohc.fdwbe, 0xF);
     assert_eq!(ohc.ldwbe, 0x0);
@@ -698,20 +723,26 @@ fn flit_tlp_type_try_from_u8_valid_type_codes() {
 
 #[test]
 fn flit_tlp_type_try_from_u8_unknown_returns_invalid_type() {
-    assert_eq!(FlitTlpType::try_from(0xFFu8).err().unwrap(), TlpError::InvalidType);
-    assert_eq!(FlitTlpType::try_from(0x01u8).err().unwrap(), TlpError::InvalidType);
+    assert_eq!(
+        FlitTlpType::try_from(0xFFu8).err().unwrap(),
+        TlpError::InvalidType
+    );
+    assert_eq!(
+        FlitTlpType::try_from(0x01u8).err().unwrap(),
+        TlpError::InvalidType
+    );
 }
 
 #[test]
 fn flit_dw0_struct_is_public_and_constructible() {
     let dw0 = FlitDW0::from_dw0(&[0x00, 0x00, 0x00, 0x00]).unwrap();
     let _: FlitTlpType = dw0.tlp_type;
-    let _: u8  = dw0.tc;
-    let _: u8  = dw0.ohc;
-    let _: u8  = dw0.ts;
-    let _: u8  = dw0.attr;
+    let _: u8 = dw0.tc;
+    let _: u8 = dw0.ohc;
+    let _: u8 = dw0.ts;
+    let _: u8 = dw0.attr;
     let _: u16 = dw0.length;
-    let _: u8  = dw0.ohc_count();
+    let _: u8 = dw0.ohc_count();
     let _: usize = dw0.total_bytes();
 }
 
@@ -775,7 +806,8 @@ fn deprecated_get_tlp_type_on_packet_delegates_to_tlp_type() {
     let pkt = TlpPacket::new(
         vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
         TlpMode::NonFlit,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(pkt.get_tlp_type(), pkt.tlp_type());
 }
 
@@ -785,7 +817,8 @@ fn deprecated_get_tlp_format_delegates_to_tlp_format() {
     let pkt = TlpPacket::new(
         vec![0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
         TlpMode::NonFlit,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(pkt.get_tlp_format(), pkt.tlp_format());
 }
 
@@ -802,7 +835,8 @@ fn deprecated_get_header_delegates_to_header() {
     let pkt = TlpPacket::new(
         vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
         TlpMode::NonFlit,
-    ).unwrap();
+    )
+    .unwrap();
     // Both return the same TlpPacketHeader; compare via tlp_type() since the
     // struct does not implement PartialEq.
     let via_old = pkt.get_header().tlp_type().unwrap();
@@ -813,10 +847,7 @@ fn deprecated_get_header_delegates_to_header() {
 #[test]
 #[allow(deprecated)]
 fn deprecated_get_tlp_type_on_header_delegates_to_tlp_type() {
-    let hdr = TlpPacketHeader::new(
-        vec![0x04, 0x00, 0x00, 0x01],
-        TlpMode::NonFlit,
-    ).unwrap();
+    let hdr = TlpPacketHeader::new(vec![0x04, 0x00, 0x00, 0x01], TlpMode::NonFlit).unwrap();
     assert_eq!(hdr.get_tlp_type(), hdr.tlp_type());
 }
 
@@ -829,10 +860,11 @@ fn tlp_packet_implements_debug() {
     let pkt = TlpPacket::new(
         vec![0x40, 0x00, 0x00, 0x01, 0xDE, 0xAD, 0xBE, 0xEF],
         TlpMode::NonFlit,
-    ).unwrap();
+    )
+    .unwrap();
     let s = format!("{:?}", pkt);
     assert!(s.contains("TlpPacket"), "expected 'TlpPacket' in: {s}");
-    assert!(s.contains("data_len"),  "expected 'data_len' in: {s}");
+    assert!(s.contains("data_len"), "expected 'data_len' in: {s}");
 }
 
 #[test]
@@ -840,17 +872,17 @@ fn tlp_packet_implements_debug_flit() {
     let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
     let s = format!("{:?}", pkt);
     assert!(s.contains("TlpPacket"), "expected 'TlpPacket' in: {s}");
-    assert!(s.contains("flit_dw0"),  "expected 'flit_dw0' in: {s}");
+    assert!(s.contains("flit_dw0"), "expected 'flit_dw0' in: {s}");
 }
 
 #[test]
 fn tlp_packet_header_implements_debug() {
-    let hdr = TlpPacketHeader::new(
-        vec![0x00, 0x00, 0x20, 0x01],
-        TlpMode::NonFlit,
-    ).unwrap();
+    let hdr = TlpPacketHeader::new(vec![0x00, 0x00, 0x20, 0x01], TlpMode::NonFlit).unwrap();
     let s = format!("{:?}", hdr);
-    assert!(s.contains("TlpPacketHeader"), "expected 'TlpPacketHeader' in: {s}");
-    assert!(s.contains("format"),          "expected 'format' in: {s}");
-    assert!(s.contains("length"),          "expected 'length' in: {s}");
+    assert!(
+        s.contains("TlpPacketHeader"),
+        "expected 'TlpPacketHeader' in: {s}"
+    );
+    assert!(s.contains("format"), "expected 'format' in: {s}");
+    assert!(s.contains("length"), "expected 'length' in: {s}");
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -602,8 +602,7 @@ fn api_all_expected_public_types_are_available() {
     let _: Option<CompletionReqDW23<[u8; 8]>> = None;
     let _: Option<MessageReqDW24<[u8; 12]>> = None;
     
-    // Ensure factory functions exist
-    let _ = new_mem_req;
+    // new_mem_req: verified by new_mem_req_factory_exists (impl Trait prevents bare reference)
     let _ = new_conf_req;
     let _ = new_cmpl_req;
     let _ = new_msg_req;

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -106,7 +106,7 @@ fn tlp_mode_flit_packet_new_succeeds() {
     // TlpMode::Flit is now implemented -- NOP flit (type 0x00, 1 DW header)
     let bytes = vec![0x00u8; 4];
     let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::Nop));
     assert!(pkt.data().is_empty());
 }
 
@@ -218,7 +218,7 @@ fn tlp_packet_new_constructor_exists() {
 fn tlp_packet_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    let result: Result<TlpType, TlpError> = packet.get_tlp_type();
+    let result: Result<TlpType, TlpError> = packet.tlp_type();
     assert!(result.is_ok());
 }
 
@@ -226,28 +226,28 @@ fn tlp_packet_get_tlp_type_returns_result() {
 fn tlp_packet_get_tlp_type_valid_mem_read() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemReadReq);
+    assert_eq!(packet.tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_mem_write() {
     let data = vec![0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemWriteReq);
+    assert_eq!(packet.tlp_type().unwrap(), TlpType::MemWriteReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_config_type0_read() {
     let data = vec![0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(packet.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
+    assert_eq!(packet.tlp_type().unwrap(), TlpType::ConfType0ReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_error_invalid_format() {
     let data = vec![0xa0, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    let result = packet.get_tlp_type();
+    let result = packet.tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidFormat);
 }
@@ -256,7 +256,7 @@ fn tlp_packet_get_tlp_type_error_invalid_format() {
 fn tlp_packet_get_tlp_type_error_invalid_type() {
     let data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    let result = packet.get_tlp_type();
+    let result = packet.tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
 }
@@ -265,7 +265,7 @@ fn tlp_packet_get_tlp_type_error_invalid_type() {
 fn tlp_packet_get_tlp_format_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    let format: Result<TlpFmt, _> = packet.get_tlp_format();
+    let format: Result<TlpFmt, _> = packet.tlp_format();
     assert!(format.is_ok());
 }
 
@@ -303,7 +303,7 @@ fn tlp_packet_header_new_constructor_exists() {
 fn tlp_packet_header_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let header = TlpPacketHeader::new(data, TlpMode::NonFlit).unwrap();
-    let result: Result<TlpType, TlpError> = header.get_tlp_type();
+    let result: Result<TlpType, TlpError> = header.tlp_type();
     assert!(result.is_ok());
 }
 
@@ -602,10 +602,12 @@ fn api_all_expected_public_types_are_available() {
     let _: Option<CompletionReqDW23<[u8; 8]>> = None;
     let _: Option<MessageReqDW24<[u8; 12]>> = None;
     
-    // new_mem_req: verified by new_mem_req_factory_exists (impl Trait prevents bare reference)
-    let _ = new_conf_req;
-    let _ = new_cmpl_req;
-    let _ = new_msg_req;
+    // All four factory functions accept impl Into<Vec<u8>>.
+    // Calling with an empty Vec<u8> satisfies inference and proves importability.
+    let _ = new_mem_req(vec![0u8; 0], &TlpFmt::NoDataHeader3DW);
+    let _ = new_conf_req(vec![0u8; 0]);
+    let _ = new_cmpl_req(vec![0u8; 0]);
+    let _ = new_msg_req(vec![0u8; 0]);
     let _ = new_atomic_req;
     let _: Option<AtomicOp> = None;
     let _: Option<AtomicWidth> = None;
@@ -718,11 +720,31 @@ fn flit_dw0_struct_is_public_and_constructible() {
 // ============================================================================
 
 #[test]
+fn tlp_packet_mode_returns_correct_mode() {
+    let non_flit = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    assert_eq!(non_flit.mode(), TlpMode::NonFlit);
+
+    let flit = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
+    assert_eq!(flit.mode(), TlpMode::Flit);
+}
+
+/// mode() is the idiomatic dispatch predicate — flit_type().is_some() is equivalent
+/// but less readable; verify both agree.
+#[test]
+fn tlp_packet_mode_consistent_with_flit_type() {
+    let nf = TlpPacket::new(vec![0x00; 4], TlpMode::NonFlit).unwrap();
+    assert_eq!(nf.mode() == TlpMode::Flit, nf.flit_type().is_some());
+
+    let fl = TlpPacket::new(vec![0x00; 4], TlpMode::Flit).unwrap();
+    assert_eq!(fl.mode() == TlpMode::Flit, fl.flit_type().is_some());
+}
+
+#[test]
 fn tlp_packet_handles_minimum_size() {
     // 4-byte header minimum
     let data = vec![0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert!(packet.get_tlp_type().is_ok());
+    assert!(packet.tlp_type().is_ok());
 }
 
 #[test]
@@ -739,4 +761,96 @@ fn tlp_packet_preserves_data_payload() {
     data.extend_from_slice(&payload);
     let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.data(), payload);
+}
+
+// ============================================================================
+// Backward Compatibility Tests — deprecated get_* aliases
+// ============================================================================
+
+/// Verify that all deprecated `get_*` aliases still compile and return the
+/// same values as their replacement methods. One test per deprecated method.
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_tlp_type_on_packet_delegates_to_tlp_type() {
+    let pkt = TlpPacket::new(
+        vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    ).unwrap();
+    assert_eq!(pkt.get_tlp_type(), pkt.tlp_type());
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_tlp_format_delegates_to_tlp_format() {
+    let pkt = TlpPacket::new(
+        vec![0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    ).unwrap();
+    assert_eq!(pkt.get_tlp_format(), pkt.tlp_format());
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_flit_type_delegates_to_flit_type() {
+    let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), pkt.flit_type());
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_header_delegates_to_header() {
+    let pkt = TlpPacket::new(
+        vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    ).unwrap();
+    // Both return the same TlpPacketHeader; compare via tlp_type() since the
+    // struct does not implement PartialEq.
+    let via_old = pkt.get_header().tlp_type().unwrap();
+    let via_new = pkt.header().tlp_type().unwrap();
+    assert_eq!(via_old, via_new);
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_get_tlp_type_on_header_delegates_to_tlp_type() {
+    let hdr = TlpPacketHeader::new(
+        vec![0x04, 0x00, 0x00, 0x01],
+        TlpMode::NonFlit,
+    ).unwrap();
+    assert_eq!(hdr.get_tlp_type(), hdr.tlp_type());
+}
+
+// ============================================================================
+// Debug trait Tests
+// ============================================================================
+
+#[test]
+fn tlp_packet_implements_debug() {
+    let pkt = TlpPacket::new(
+        vec![0x40, 0x00, 0x00, 0x01, 0xDE, 0xAD, 0xBE, 0xEF],
+        TlpMode::NonFlit,
+    ).unwrap();
+    let s = format!("{:?}", pkt);
+    assert!(s.contains("TlpPacket"), "expected 'TlpPacket' in: {s}");
+    assert!(s.contains("data_len"),  "expected 'data_len' in: {s}");
+}
+
+#[test]
+fn tlp_packet_implements_debug_flit() {
+    let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x00], TlpMode::Flit).unwrap();
+    let s = format!("{:?}", pkt);
+    assert!(s.contains("TlpPacket"), "expected 'TlpPacket' in: {s}");
+    assert!(s.contains("flit_dw0"),  "expected 'flit_dw0' in: {s}");
+}
+
+#[test]
+fn tlp_packet_header_implements_debug() {
+    let hdr = TlpPacketHeader::new(
+        vec![0x00, 0x00, 0x20, 0x01],
+        TlpMode::NonFlit,
+    ).unwrap();
+    let s = format!("{:?}", hdr);
+    assert!(s.contains("TlpPacketHeader"), "expected 'TlpPacketHeader' in: {s}");
+    assert!(s.contains("format"),          "expected 'format' in: {s}");
+    assert!(s.contains("length"),          "expected 'length' in: {s}");
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -540,7 +540,7 @@ fn atomic_req_returns_err_for_short_payload() {
 fn api_all_expected_public_types_are_available() {
     // This test will fail to compile if any public type is removed or renamed
     use rtlp_lib::{
-        TlpError, TlpFmt, TlpFormatEncodingType, TlpType, TlpMode,
+        TlpError, TlpFmt, TlpType, TlpMode,
         TlpPacket, TlpPacketHeader,
         MemRequest3DW, MemRequest4DW, ConfigRequest,
         CompletionReqDW23, MessageReqDW24,
@@ -553,7 +553,6 @@ fn api_all_expected_public_types_are_available() {
     // Use types to prevent unused warnings
     let _: Option<TlpError> = None;
     let _: Option<TlpFmt> = None;
-    let _: Option<TlpFormatEncodingType> = None;
     let _: Option<TlpType> = None;
     let _: Option<TlpMode> = None;
     let _: Option<TlpPacket> = None;

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -451,7 +451,7 @@ fn new_mem_req_factory_exists() {
 fn new_conf_req_factory_exists() {
     let bytes = vec![0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let format = TlpFmt::NoDataHeader3DW;
-    let result = new_conf_req(bytes, &format);
+    let result = new_conf_req(bytes);
     // Factory returns Box<dyn ConfigurationRequest>, verify it has the expected methods
     let _req_id = result.req_id();
     let _bus_nr = result.bus_nr();
@@ -461,7 +461,7 @@ fn new_conf_req_factory_exists() {
 fn new_cmpl_req_factory_exists() {
     let bytes = vec![0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
     let format = TlpFmt::NoDataHeader3DW;
-    let result = new_cmpl_req(bytes, &format);
+    let result = new_cmpl_req(bytes);
     // Factory returns Box<dyn CompletionRequest>, verify it has the expected methods
     let _req_id = result.req_id();
     let _cmpl_stat = result.cmpl_stat();
@@ -470,8 +470,7 @@ fn new_cmpl_req_factory_exists() {
 #[test]
 fn new_msg_req_factory_exists() {
     let bytes = vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let format = TlpFmt::NoDataHeader3DW;
-    let result = new_msg_req(bytes, &format);
+    let result = new_msg_req(bytes);
     // Factory returns Box<dyn MessageRequest>, verify it has the expected methods
     let _req_id = result.req_id();
     let _msg_code = result.msg_code();

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -73,13 +73,17 @@ fn tlp_mode_implements_debug_clone_copy_partialeq() {
 }
 
 #[test]
-fn tlp_mode_flit_returns_not_implemented_for_packet() {
-    let bytes = vec![0x00u8; 8];
-    assert_eq!(TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+fn tlp_mode_flit_packet_new_succeeds() {
+    // TlpMode::Flit is now implemented -- NOP flit (type 0x00, 1 DW header)
+    let bytes = vec![0x00u8; 4];
+    let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+    assert!(pkt.get_data().is_empty());
 }
 
 #[test]
 fn tlp_mode_flit_returns_not_implemented_for_header() {
+    // TlpPacketHeader::new() with Flit still returns NotImplemented
     let bytes = vec![0x00u8; 4];
     assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -16,6 +16,7 @@ fn error_type_exists_and_is_public() {
     let _err2: TlpError = TlpError::InvalidType;
     let _err3: TlpError = TlpError::UnsupportedCombination;
     let _err4: TlpError = TlpError::InvalidLength;
+    let _err5: TlpError = TlpError::NotImplemented;
 }
 
 #[test]
@@ -29,6 +30,57 @@ fn error_type_implements_debug() {
 fn error_type_implements_partialeq() {
     assert_eq!(TlpError::InvalidFormat, TlpError::InvalidFormat);
     assert_ne!(TlpError::InvalidFormat, TlpError::InvalidType);
+}
+
+#[test]
+fn error_not_implemented_exists_and_is_distinct() {
+    let e = TlpError::NotImplemented;
+    assert_eq!(e, TlpError::NotImplemented);
+    assert_ne!(e, TlpError::InvalidFormat);
+    assert_ne!(e, TlpError::InvalidType);
+    assert_ne!(e, TlpError::UnsupportedCombination);
+    assert_ne!(e, TlpError::InvalidLength);
+    let s = format!("{:?}", e);
+    assert!(s.contains("NotImplemented"));
+}
+
+// ============================================================================
+// TlpMode Enum API Tests
+// ============================================================================
+
+#[test]
+fn tlp_mode_enum_has_expected_variants() {
+    let _m1: TlpMode = TlpMode::NonFlit;
+    let _m2: TlpMode = TlpMode::Flit;
+}
+
+#[test]
+fn tlp_mode_implements_debug_clone_copy_partialeq() {
+    assert_eq!(TlpMode::NonFlit, TlpMode::NonFlit);
+    assert_ne!(TlpMode::NonFlit, TlpMode::Flit);
+
+    let m = TlpMode::NonFlit;
+    let m2 = m;        // Copy
+    let m3 = m.clone(); // Clone
+    assert_eq!(m2, TlpMode::NonFlit);
+    assert_eq!(m3, TlpMode::NonFlit);
+
+    let s = format!("{:?}", TlpMode::NonFlit);
+    assert!(s.contains("NonFlit"));
+    let s2 = format!("{:?}", TlpMode::Flit);
+    assert!(s2.contains("Flit"));
+}
+
+#[test]
+fn tlp_mode_flit_returns_not_implemented_for_packet() {
+    let bytes = vec![0x00u8; 8];
+    assert_eq!(TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
+}
+
+#[test]
+fn tlp_mode_flit_returns_not_implemented_for_header() {
+    let bytes = vec![0x00u8; 4];
+    assert_eq!(TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(), TlpError::NotImplemented);
 }
 
 // ============================================================================
@@ -125,13 +177,13 @@ fn tlp_type_implements_debug() {
 #[test]
 fn tlp_packet_new_constructor_exists() {
     let data = vec![0x00; 12];
-    let _packet = TlpPacket::new(data).unwrap();
+    let _packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     let result: Result<TlpType, TlpError> = packet.get_tlp_type();
     assert!(result.is_ok());
 }
@@ -139,28 +191,28 @@ fn tlp_packet_get_tlp_type_returns_result() {
 #[test]
 fn tlp_packet_get_tlp_type_valid_mem_read() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_mem_write() {
     let data = vec![0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::MemWriteReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_valid_config_type0_read() {
     let data = vec![0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
 }
 
 #[test]
 fn tlp_packet_get_tlp_type_error_invalid_format() {
     let data = vec![0xa0, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidFormat);
@@ -169,7 +221,7 @@ fn tlp_packet_get_tlp_type_error_invalid_format() {
 #[test]
 fn tlp_packet_get_tlp_type_error_invalid_type() {
     let data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
@@ -178,7 +230,7 @@ fn tlp_packet_get_tlp_type_error_invalid_type() {
 #[test]
 fn tlp_packet_get_tlp_format_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     let format: Result<TlpFmt, _> = packet.get_tlp_format();
     assert!(format.is_ok());
 }
@@ -186,7 +238,7 @@ fn tlp_packet_get_tlp_format_exists() {
 #[test]
 fn tlp_packet_get_data_exists() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC, 0xDD];
-    let packet = TlpPacket::new(data.clone()).unwrap();
+    let packet = TlpPacket::new(data.clone(), TlpMode::NonFlit).unwrap();
     let returned_data = packet.get_data();
     assert_eq!(returned_data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
 }
@@ -198,13 +250,13 @@ fn tlp_packet_get_data_exists() {
 #[test]
 fn tlp_packet_header_new_constructor_exists() {
     let data = vec![0x00; 12];
-    let _header = TlpPacketHeader::new(data).unwrap();
+    let _header = TlpPacketHeader::new(data, TlpMode::NonFlit).unwrap();
 }
 
 #[test]
 fn tlp_packet_header_get_tlp_type_returns_result() {
     let data = vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let header = TlpPacketHeader::new(data).unwrap();
+    let header = TlpPacketHeader::new(data, TlpMode::NonFlit).unwrap();
     let result: Result<TlpType, TlpError> = header.get_tlp_type();
     assert!(result.is_ok());
 }
@@ -397,7 +449,7 @@ fn new_atomic_req_factory_exists() {
     // DW0: fmt=0b010 (WithData3DW), type=0b01100 (FetchAdd) → byte0 = 0x4C
     let mut bytes = vec![0x4C, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 12]); // 8-byte hdr + 4-byte operand
-    let pkt = TlpPacket::new(bytes).unwrap();
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
     let result = new_atomic_req(&pkt);
     assert!(result.is_ok());
     let ar = result.unwrap();
@@ -448,7 +500,7 @@ fn atomic_req_returns_err_for_non_atomic_type() {
     // MemRead 3DW NoData: fmt=0b000, type=0b00000 → byte0 = 0x00
     let mut bytes = vec![0x00, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 16]);
-    let pkt = TlpPacket::new(bytes).unwrap();
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::UnsupportedCombination);
 }
@@ -459,7 +511,7 @@ fn atomic_req_returns_err_for_nodata_format() {
     // get_tlp_type() returns UnsupportedCombination for this combo
     let mut bytes = vec![0x0D, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 16]);
-    let pkt = TlpPacket::new(bytes).unwrap();
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::UnsupportedCombination);
 }
@@ -470,7 +522,7 @@ fn atomic_req_returns_err_for_short_payload() {
     // fmt=0b010, type=0b01100 → byte0 = 0x4C
     let mut bytes = vec![0x4C, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&[0u8; 4]);
-    let pkt = TlpPacket::new(bytes).unwrap();
+    let pkt = TlpPacket::new(bytes, TlpMode::NonFlit).unwrap();
     let result = new_atomic_req(&pkt);
     assert_eq!(result.err().unwrap(), TlpError::InvalidLength);
 }
@@ -483,7 +535,7 @@ fn atomic_req_returns_err_for_short_payload() {
 fn api_all_expected_public_types_are_available() {
     // This test will fail to compile if any public type is removed or renamed
     use rtlp_lib::{
-        TlpError, TlpFmt, TlpFormatEncodingType, TlpType,
+        TlpError, TlpFmt, TlpFormatEncodingType, TlpType, TlpMode,
         TlpPacket, TlpPacketHeader,
         MemRequest3DW, MemRequest4DW, ConfigRequest,
         CompletionReqDW23, MessageReqDW24,
@@ -496,6 +548,7 @@ fn api_all_expected_public_types_are_available() {
     let _: Option<TlpFmt> = None;
     let _: Option<TlpFormatEncodingType> = None;
     let _: Option<TlpType> = None;
+    let _: Option<TlpMode> = None;
     let _: Option<TlpPacket> = None;
     let _: Option<TlpPacketHeader> = None;
     // Bitfield structs have generic parameters, use with concrete type
@@ -523,14 +576,14 @@ fn api_all_expected_public_types_are_available() {
 fn tlp_packet_handles_minimum_size() {
     // 4-byte header minimum
     let data = vec![0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert!(packet.get_tlp_type().is_ok());
 }
 
 #[test]
 fn tlp_packet_handles_empty_data_section() {
     let data = vec![0x00, 0x00, 0x00, 0x01];
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.get_data(), Vec::<u8>::new());
 }
 
@@ -539,6 +592,6 @@ fn tlp_packet_preserves_data_payload() {
     let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
     let mut data = vec![0x00, 0x00, 0x00, 0x01];
     data.extend_from_slice(&payload);
-    let packet = TlpPacket::new(data).unwrap();
+    let packet = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(packet.get_data(), payload);
 }

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -11,8 +11,8 @@
 //! | 1 | ✅ passes today | `FlitDW0::from_dw0()` ← **implemented** |
 //! | 2 | ✅ passes today | `FlitTlpType::base_header_dw()` ← **implemented** |
 //! | 3 | ✅ passes today | `FlitOhcA` + `validate_mandatory_ohc()` ← **implemented** |
-//! | 4 | `#[ignore]` | `FlitStreamWalker` / stream iterator |
-//! | 5 | `#[ignore]` | `TlpPacket::new_flit()` fully wired |
+//! | 4 | ✅ passes today | `FlitStreamWalker` ← **implemented** |
+//! | 5 | ✅ passes today | `TlpPacket::new_flit()` ← **implemented** |
 //!
 //! For non-flit tests see `tests/non_flit_tests.rs`.
 //! For API surface tests see `tests/api_tests.rs`.
@@ -175,12 +175,11 @@ pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
 // ============================================================================
 
 #[test]
-fn flit_packet_new_returns_not_implemented() {
-    let bytes = FM_MRD32_MIN.to_vec();
-    assert_eq!(
-        TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(),
-        TlpError::NotImplemented
-    );
+fn flit_packet_new_succeeds_for_valid_flit() {
+    // TlpMode::Flit is now implemented -- MRd32 flit (3 DW header, no payload)
+    let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+    assert!(pkt.get_data().is_empty()); // read request, no payload
 }
 
 #[test]
@@ -539,88 +538,101 @@ fn flit_t3_cfgwr_missing_mandatory_ohc_a3() {
 }
 
 // ============================================================================
-// Tier 4 — Packed stream walking
-//
-// #[ignore] — pending: FlitStreamWalker not yet implemented
+// Tier 4 -- Packed stream walking
 // ============================================================================
 
 #[test]
-#[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
 fn flit_t4_stream_fragment_0_offsets() {
-    todo!(
-        "let walker = FlitStreamWalker::new(&FM_STREAM_FRAGMENT_0);
-         let entries: Vec<_> = walker.collect();
-         assert_eq!(entries[0], (0,  FlitTlpType::Nop,       4));
-         assert_eq!(entries[1], (4,  FlitTlpType::MemRead32, 12));
-         assert_eq!(entries[2], (16, FlitTlpType::MemWrite32,16));
-         assert_eq!(entries[3], (32, FlitTlpType::UioMemRead,16));
-         assert_eq!(entries.len(), 4);"
-    );
+    // FM_STREAM_FRAGMENT_0 contains 4 back-to-back TLPs:
+    //   NOP (4B) + MRd32 (12B) + MWr32 (16B) + UIOMRd (16B) = 48B total
+    let entries: Vec<_> = FlitStreamWalker::new(&FM_STREAM_FRAGMENT_0)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(entries.len(), 4);
+    assert_eq!(entries[0], (0,  FlitTlpType::Nop,       4));
+    assert_eq!(entries[1], (4,  FlitTlpType::MemRead32, 12));
+    assert_eq!(entries[2], (16, FlitTlpType::MemWrite32, 16));
+    assert_eq!(entries[3], (32, FlitTlpType::UioMemRead, 16));
 }
 
 #[test]
-#[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
+fn flit_t4_stream_walker_returns_none_at_end() {
+    // Walker stops cleanly after the last TLP
+    let mut walker = FlitStreamWalker::new(&FM_NOP);
+    assert!(walker.next().is_some()); // NOP
+    assert!(walker.next().is_none()); // end of stream
+}
+
+#[test]
 fn flit_t4_stream_truncated_payload_error() {
+    // FM_UIOMWR64_MIN with last byte removed -- payload is truncated
     let mut truncated = FM_UIOMWR64_MIN.to_vec();
     truncated.pop();
-    todo!(
-        "FlitStreamWalker::new(&truncated).next() → Err(TlpError::InvalidLength)"
-    );
+    let result: Result<Vec<_>, _> = FlitStreamWalker::new(&truncated).collect();
+    assert_eq!(result.err().unwrap(), TlpError::InvalidLength);
 }
 
 // ============================================================================
-// Tier 5 — End-to-end TlpMode::Flit pipeline
-//
-// #[ignore] — pending: TlpPacket::new_flit() fully wired
+// Tier 5 -- End-to-end TlpMode::Flit pipeline
 // ============================================================================
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_mrd32_min() {
-    todo!(
-        "TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap()
-         → get_data() is empty (read request, no payload)"
-    );
+    // MRd32 flit: 3 DW base header, no payload despite Length=1
+    let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+    assert!(pkt.get_data().is_empty());
 }
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_mwr32_min() {
-    todo!(
-        "TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap()
-         → get_data() == [0xDE, 0xAD, 0xBE, 0xEF]"
-    );
+    // MWr32 flit: 3 DW header + 1 DW payload
+    let pkt = TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
+    assert_eq!(pkt.get_data(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
 }
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_cas32() {
-    todo!(
-        "payload == [0x11,0x11,0x11,0x11, 0x22,0x22,0x22,0x22]"
-    );
+    // CAS32 flit: 3 DW header + 2 DW payload (compare + swap)
+    let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::CompareSwap32));
+    assert_eq!(pkt.get_data(), vec![
+        0x11, 0x11, 0x11, 0x11, // compare
+        0x22, 0x22, 0x22, 0x22, // swap
+    ]);
 }
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_dmwr32() {
-    todo!(
-        "payload == [0xC0, 0xFF, 0xEE, 0x00]"
-    );
+    // DMWr32 flit: 3 DW header + 1 DW payload
+    let pkt = TlpPacket::new(FM_DMWR32.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::DeferrableMemWrite32));
+    assert_eq!(pkt.get_data(), vec![0xC0, 0xFF, 0xEE, 0x00]);
 }
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_uiomwr64() {
-    todo!(
-        "payload == [0x11,0x22,0x33,0x44, 0x55,0x66,0x77,0x88]"
-    );
+    // UIOMWr64 flit: 4 DW header + 2 DW payload
+    let pkt = TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::UioMemWrite));
+    assert_eq!(pkt.get_data(), vec![
+        0x11, 0x22, 0x33, 0x44,
+        0x55, 0x66, 0x77, 0x88,
+    ]);
 }
 
 #[test]
-#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_nop_has_no_data() {
-    todo!(
-        "TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap()
-         → get_data().is_empty()"
-    );
+    // NOP flit: 1 DW header, no payload
+    let pkt = TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+    assert!(pkt.get_data().is_empty());
+}
+
+#[test]
+fn flit_t5_nonflit_packet_get_flit_type_returns_none() {
+    // Non-flit packets must return None from get_flit_type()
+    let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x01], TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_flit_type(), None);
 }

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -1,0 +1,575 @@
+//! Flit Mode Tests (PCIe 6.x)
+//!
+//! Scope: parser tests for TLP byte streams as they appear inside a PCIe 6.x FLIT.
+//! These are NOT full 256-byte FLIT containers — no DLP, CRC or FEC bytes.
+//!
+//! # Tier structure
+//!
+//! | Tier | Status | Unlock condition |
+//! |------|--------|-----------------|
+//! | 0 | ✅ passes today | N/A — permanent stub regression guard |
+//! | 1 | `#[ignore]` | `FlitDW0` struct + `flit_dw0_from_bytes()` |
+//! | 2 | `#[ignore]` | `FlitTlpType` enum + header-size table |
+//! | 3 | `#[ignore]` | OHC parser + `TlpError::MissingMandatoryOhc` |
+//! | 4 | `#[ignore]` | `FlitStreamWalker` / stream iterator |
+//! | 5 | `#[ignore]` | `TlpPacket::new_flit()` fully wired |
+//!
+//! For non-flit tests see `tests/non_flit_tests.rs`.
+//! For API surface tests see `tests/api_tests.rs`.
+//! Design rationale: `docs/flit_mode_test_plan.md`.
+
+use rtlp_lib::*;
+
+// ============================================================================
+// FM_* test vectors — from docs/flit_mode_tlp_examples.md
+//
+// DW0 flit-mode encoding:
+//   Byte 0 = Type[7:0]   (flat 8-bit type code, NOT non-flit fmt+type)
+//   Byte 1 = TC[2:0] | OHC[4:0]
+//   Byte 2 = TS[2:0] | Attr[2:0] | Length[9:8]
+//   Byte 3 = Length[7:0]
+// ============================================================================
+
+/// Flit-mode NOP. Smallest possible header-base object (1 DW, no payload).
+pub const FM_NOP: [u8; 4] = [
+    0x00, 0x00, 0x00, 0x00,
+];
+
+/// Minimal 32-bit Memory Read Request. Length=1 DW, no OHC, no payload.
+pub const FM_MRD32_MIN: [u8; 12] = [
+    0x03, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+
+/// 32-bit Memory Read Request with OHC-A1 carrying PASID=0x12345, fdwbe=0xF, ldwbe=0x0.
+pub const FM_MRD32_A1_PASID: [u8; 16] = [
+    0x03, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x01, 0x23, 0x45, 0x0F,
+];
+
+/// Minimal 32-bit Memory Write Request. Length=1 DW, no OHC, payload=0xDEADBEEF.
+pub const FM_MWR32_MIN: [u8; 16] = [
+    0x40, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xDE, 0xAD, 0xBE, 0xEF,
+];
+
+/// 32-bit Memory Write Request with OHC-A1. fdwbe=0x3 (partial-byte write).
+pub const FM_MWR32_PARTIAL_A1: [u8; 20] = [
+    0x40, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x03,
+    0xAA, 0xBB, 0xCC, 0xDD,
+];
+
+/// I/O Write Request with mandatory OHC-A2. fdwbe=0xF.
+pub const FM_IOWR_A2: [u8; 20] = [
+    0x42, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0F,
+    0x10, 0x20, 0x30, 0x40,
+];
+
+/// Type0 Configuration Write Request with mandatory OHC-A3. fdwbe=0xF.
+pub const FM_CFGWR0_A3: [u8; 20] = [
+    0x44, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0F,
+    0x44, 0x33, 0x22, 0x11,
+];
+
+/// Minimal UIO Memory Read Request (PCIe 6.1+ UIO). 4 DW base header, Length=2 DW, no payload.
+pub const FM_UIOMRD64_MIN: [u8; 16] = [
+    0x22, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+
+/// Minimal UIO Memory Write Request (PCIe 6.1+ UIO). 4 DW base header, 2 DW payload.
+pub const FM_UIOMWR64_MIN: [u8; 24] = [
+    0x61, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x11, 0x22, 0x33, 0x44,
+    0x55, 0x66, 0x77, 0x88,
+];
+
+/// Message routed to RC, no data.
+pub const FM_MSG_TO_RC: [u8; 12] = [
+    0x30, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+
+/// Message with data, routed to RC.
+pub const FM_MSGD_TO_RC: [u8; 16] = [
+    0x70, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xAA, 0x55, 0xAA, 0x55,
+];
+
+/// 32-bit FetchAdd AtomicOp Request. Operand = 0x01000000.
+pub const FM_FETCHADD32: [u8; 16] = [
+    0x4C, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00,
+];
+
+/// 32-bit Compare-and-Swap AtomicOp Request. Compare=0x11111111, Swap=0x22222222.
+pub const FM_CAS32: [u8; 20] = [
+    0x4E, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x11, 0x11, 0x11, 0x11,
+    0x22, 0x22, 0x22, 0x22,
+];
+
+/// 32-bit Deferrable Memory Write Request.
+pub const FM_DMWR32: [u8; 16] = [
+    0x5B, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xC0, 0xFF, 0xEE, 0x00,
+];
+
+/// Packed stream fragment: NOP + MRd32 + MWr32 + UIOMRd64 back-to-back.
+pub const FM_STREAM_FRAGMENT_0: [u8; 48] = [
+    // NOP (4 bytes, offset 0)
+    0x00, 0x00, 0x00, 0x00,
+    // MRd32 (12 bytes, offset 4)
+    0x03, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    // MWr32 (16 bytes, offset 16)
+    0x40, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0xDE, 0xAD, 0xBE, 0xEF,
+    // UIOMRd64 (16 bytes, offset 32)
+    0x22, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+];
+
+/// Local TLP Prefix token (Appendix A — not a standalone transaction).
+pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
+    0x8D, 0x00, 0x00, 0x00,
+];
+
+// ============================================================================
+// Tier 0 — Current stub behavior
+//
+// These tests PASS TODAY and act as permanent regression guards.
+// They verify that TlpMode::Flit correctly returns NotImplemented until
+// the flit parser is implemented.
+// ============================================================================
+
+#[test]
+fn flit_packet_new_returns_not_implemented() {
+    let bytes = FM_MRD32_MIN.to_vec();
+    assert_eq!(
+        TlpPacket::new(bytes, TlpMode::Flit).err().unwrap(),
+        TlpError::NotImplemented
+    );
+}
+
+#[test]
+fn flit_header_new_returns_not_implemented() {
+    let bytes = FM_MRD32_MIN.to_vec();
+    assert_eq!(
+        TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(),
+        TlpError::NotImplemented
+    );
+}
+
+#[test]
+fn flit_byte_vectors_have_correct_sizes() {
+    // Compile-time size sanity check — no parser required.
+    assert_eq!(FM_NOP.len(),                 4);
+    assert_eq!(FM_MRD32_MIN.len(),          12);
+    assert_eq!(FM_MRD32_A1_PASID.len(),     16);
+    assert_eq!(FM_MWR32_MIN.len(),          16);
+    assert_eq!(FM_MWR32_PARTIAL_A1.len(),   20);
+    assert_eq!(FM_IOWR_A2.len(),            20);
+    assert_eq!(FM_CFGWR0_A3.len(),          20);
+    assert_eq!(FM_UIOMRD64_MIN.len(),       16);
+    assert_eq!(FM_UIOMWR64_MIN.len(),       24);
+    assert_eq!(FM_MSG_TO_RC.len(),          12);
+    assert_eq!(FM_MSGD_TO_RC.len(),         16);
+    assert_eq!(FM_FETCHADD32.len(),         16);
+    assert_eq!(FM_CAS32.len(),              20);
+    assert_eq!(FM_DMWR32.len(),             16);
+    assert_eq!(FM_STREAM_FRAGMENT_0.len(),  48);
+    assert_eq!(FM_LOCAL_PREFIX_ONLY.len(),   4);
+}
+
+#[test]
+fn flit_dw0_type_bytes_are_correct() {
+    // Verify type code (byte 0) for each vector without any parser.
+    assert_eq!(FM_NOP[0],               0x00, "FM_NOP type");
+    assert_eq!(FM_MRD32_MIN[0],         0x03, "FM_MRD32_MIN type");
+    assert_eq!(FM_MRD32_A1_PASID[0],    0x03, "FM_MRD32_A1_PASID type");
+    assert_eq!(FM_MWR32_MIN[0],         0x40, "FM_MWR32_MIN type");
+    assert_eq!(FM_MWR32_PARTIAL_A1[0],  0x40, "FM_MWR32_PARTIAL_A1 type");
+    assert_eq!(FM_IOWR_A2[0],           0x42, "FM_IOWR_A2 type");
+    assert_eq!(FM_CFGWR0_A3[0],         0x44, "FM_CFGWR0_A3 type");
+    assert_eq!(FM_UIOMRD64_MIN[0],      0x22, "FM_UIOMRD64_MIN type");
+    assert_eq!(FM_UIOMWR64_MIN[0],      0x61, "FM_UIOMWR64_MIN type");
+    assert_eq!(FM_MSG_TO_RC[0],         0x30, "FM_MSG_TO_RC type");
+    assert_eq!(FM_MSGD_TO_RC[0],        0x70, "FM_MSGD_TO_RC type");
+    assert_eq!(FM_FETCHADD32[0],        0x4C, "FM_FETCHADD32 type");
+    assert_eq!(FM_CAS32[0],             0x4E, "FM_CAS32 type");
+    assert_eq!(FM_DMWR32[0],            0x5B, "FM_DMWR32 type");
+    assert_eq!(FM_LOCAL_PREFIX_ONLY[0], 0x8D, "FM_LOCAL_PREFIX_ONLY type");
+}
+
+#[test]
+fn flit_dw0_ohc_bytes_are_correct() {
+    // Verify OHC presence flag (byte 1, bits[4:0]) for vectors with OHC.
+    let ohc = |b: u8| b & 0x1F; // lower 5 bits = OHC field
+
+    // No OHC
+    assert_eq!(ohc(FM_NOP[1]),              0x00, "FM_NOP ohc");
+    assert_eq!(ohc(FM_MRD32_MIN[1]),        0x00, "FM_MRD32_MIN ohc");
+    assert_eq!(ohc(FM_MWR32_MIN[1]),        0x00, "FM_MWR32_MIN ohc");
+    // OHC-A1 present (bit 0 set)
+    assert_eq!(ohc(FM_MRD32_A1_PASID[1]),   0x01, "FM_MRD32_A1_PASID ohc-A1");
+    assert_eq!(ohc(FM_MWR32_PARTIAL_A1[1]), 0x01, "FM_MWR32_PARTIAL_A1 ohc-A1");
+    // OHC-A2/A3 present (bit 0 set via OHC-A presence)
+    assert_eq!(ohc(FM_IOWR_A2[1]),          0x01, "FM_IOWR_A2 ohc-A2");
+    assert_eq!(ohc(FM_CFGWR0_A3[1]),        0x01, "FM_CFGWR0_A3 ohc-A3");
+}
+
+// ============================================================================
+// Tier 1 — Flit DW0 field extraction
+//
+// #[ignore] — pending: FlitDW0 struct and flit_dw0_from_bytes() in src/lib.rs
+//
+// Unlock: add `pub fn flit_dw0_from_bytes(b: &[u8]) -> Result<FlitDW0, TlpError>`
+//         and `pub struct FlitDW0 { tlp_type, tc, ohc, ts, attr, length }`
+// ============================================================================
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_nop_dw0_fields() {
+    todo!("FlitDW0::from_dw0(FM_NOP) → type=Nop, tc=0, ohc=0, length=0");
+}
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_mrd32_dw0_fields() {
+    todo!("FlitDW0::from_dw0(FM_MRD32_MIN) → type=MemRead32, tc=0, ohc=0, length=1");
+}
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_mrd32_a1_dw0_ohc_present() {
+    todo!("FlitDW0::from_dw0(FM_MRD32_A1_PASID) → ohc=0x01 (OHC-A1 bit set)");
+}
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_mwr32_dw0_fields() {
+    todo!("FlitDW0::from_dw0(FM_MWR32_MIN) → type=MemWrite32, length=1");
+}
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_uiomrd64_dw0_fields() {
+    todo!("FlitDW0::from_dw0(FM_UIOMRD64_MIN) → type=UioMemRead, length=2");
+}
+
+#[test]
+#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
+fn flit_t1_cas32_dw0_length_is_2() {
+    todo!("FlitDW0::from_dw0(FM_CAS32) → length=2 (2 DW payload: compare + swap)");
+}
+
+// ============================================================================
+// Tier 2 — Per-vector header + size validation
+//
+// #[ignore] — pending: FlitTlpType enum and type-to-header-size table
+//
+// Unlock: add `pub enum FlitTlpType` and a function to compute:
+//   header_bytes = (base_header_dw(type) + ohc_count) * 4
+//   total_bytes  = header_bytes + length_dw * 4
+// ============================================================================
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_nop_sizes() {
+    todo!(
+        "FM_NOP: FlitTlpType::Nop, base_header=1DW, ohc=0, payload=0DW, total=4B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_mrd32_min_sizes() {
+    todo!(
+        "FM_MRD32_MIN: FlitTlpType::MemRead32, base=3DW, ohc=0, payload=0DW (read!), total=12B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_mrd32_a1_sizes() {
+    todo!(
+        "FM_MRD32_A1_PASID: base=3DW, ohc=1DW, payload=0DW, total=16B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_mwr32_min_sizes() {
+    todo!(
+        "FM_MWR32_MIN: base=3DW, ohc=0, payload=1DW, total=16B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_mwr32_partial_a1_sizes() {
+    todo!(
+        "FM_MWR32_PARTIAL_A1: base=3DW, ohc=1DW, payload=1DW, total=20B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_iowr_a2_sizes() {
+    todo!(
+        "FM_IOWR_A2: FlitTlpType::IoWrite, base=3DW, ohc=1DW, payload=1DW, total=20B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_cfgwr0_a3_sizes() {
+    todo!(
+        "FM_CFGWR0_A3: FlitTlpType::CfgWrite0, base=3DW, ohc=1DW, payload=1DW, total=20B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_uiomrd64_sizes() {
+    todo!(
+        "FM_UIOMRD64_MIN: FlitTlpType::UioMemRead, base=4DW, ohc=0, payload=0DW, total=16B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_uiomwr64_sizes() {
+    todo!(
+        "FM_UIOMWR64_MIN: FlitTlpType::UioMemWrite, base=4DW, ohc=0, payload=2DW, total=24B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_cas32_sizes() {
+    todo!(
+        "FM_CAS32: FlitTlpType::CompareSwap32, base=3DW, ohc=0, payload=2DW, total=20B"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
+fn flit_t2_dmwr32_type_and_sizes() {
+    todo!(
+        "FM_DMWR32: FlitTlpType::DeferrableMemWrite32, base=3DW, ohc=0, payload=1DW, total=16B"
+    );
+}
+
+// ============================================================================
+// Tier 3 — OHC field parsing and mandatory OHC validation
+//
+// #[ignore] — pending: OHC parser + TlpError::MissingMandatoryOhc variant
+//
+// Unlock:
+//   - `pub struct FlitOhc { a1: Option<OhcA1>, ... }`
+//   - `TlpError::MissingMandatoryOhc`
+//   - Parser enforces: IO requires OHC-A2, Config requires OHC-A3
+// ============================================================================
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_mrd32_a1_pasid_extraction() {
+    todo!(
+        "FM_MRD32_A1_PASID: OHC-A1 word = [0x01,0x23,0x45,0x0F]
+         → PASID = 0x12345, fdwbe = 0xF, ldwbe = 0x0"
+    );
+}
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_mwr32_partial_a1_be_extraction() {
+    todo!(
+        "FM_MWR32_PARTIAL_A1: OHC-A1 word = [0x00,0x00,0x00,0x03]
+         → fdwbe = 0x3 (partial-byte write), ldwbe = 0x0"
+    );
+}
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_iowr_a2_mandatory_ohc_present() {
+    todo!(
+        "FM_IOWR_A2: OHC-A2 present (byte1 bit0=1)
+         → parser succeeds and extracts fdwbe=0xF"
+    );
+}
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_iowr_missing_mandatory_ohc_a2() {
+    // Negative test: FM_IOWR_A2 with byte1 cleared (no OHC declared)
+    // Expected: Err(TlpError::MissingMandatoryOhc)
+    let mut bad = FM_IOWR_A2.to_vec();
+    bad[1] = 0x00; // clear OHC flags — mandatory OHC-A2 missing
+    todo!(
+        "parse_flit_tlp(&bad) → Err(TlpError::MissingMandatoryOhc)"
+    );
+}
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_cfgwr0_a3_mandatory_ohc_present() {
+    todo!(
+        "FM_CFGWR0_A3: OHC-A3 present
+         → parser succeeds and extracts fdwbe=0xF"
+    );
+}
+
+#[test]
+#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
+fn flit_t3_cfgwr_missing_mandatory_ohc_a3() {
+    // Negative test: FM_CFGWR0_A3 with byte1 cleared
+    let mut bad = FM_CFGWR0_A3.to_vec();
+    bad[1] = 0x00; // clear OHC flags — mandatory OHC-A3 missing
+    todo!(
+        "parse_flit_tlp(&bad) → Err(TlpError::MissingMandatoryOhc)"
+    );
+}
+
+// ============================================================================
+// Tier 4 — Packed stream walking
+//
+// #[ignore] — pending: FlitStreamWalker or equivalent iterator in src/lib.rs
+//
+// Unlock: `pub struct FlitStreamWalker<'a>` or `flit_stream_iter(bytes: &[u8])`
+//   yields `(offset: usize, FlitTlpType, total_size: usize)` for each TLP
+// ============================================================================
+
+#[test]
+#[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
+fn flit_t4_stream_fragment_0_offsets() {
+    // FM_STREAM_FRAGMENT_0 contains 4 back-to-back TLPs:
+    //   offset  0 → NOP,     size  4B
+    //   offset  4 → MRd32,   size 12B
+    //   offset 16 → MWr32,   size 16B
+    //   offset 32 → UIOMRd,  size 16B
+    //   offset 48 → end
+    todo!(
+        "let walker = FlitStreamWalker::new(&FM_STREAM_FRAGMENT_0);
+         let entries: Vec<_> = walker.collect();
+         assert_eq!(entries[0], (0,  FlitTlpType::Nop,       4));
+         assert_eq!(entries[1], (4,  FlitTlpType::MemRead32, 12));
+         assert_eq!(entries[2], (16, FlitTlpType::MemWrite32,16));
+         assert_eq!(entries[3], (32, FlitTlpType::UioMemRead,16));
+         assert_eq!(entries.len(), 4);"
+    );
+}
+
+#[test]
+#[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
+fn flit_t4_stream_truncated_payload_error() {
+    // FM_UIOMWR64_MIN with last byte removed → total-size check must fail
+    let mut truncated = FM_UIOMWR64_MIN.to_vec();
+    truncated.pop();
+    todo!(
+        "FlitStreamWalker::new(&truncated).next() → Err(TlpError::InvalidLength)"
+    );
+}
+
+// ============================================================================
+// Tier 5 — End-to-end TlpMode::Flit pipeline
+//
+// #[ignore] — pending: TlpPacket::new_flit() fully wired in src/lib.rs
+//
+// Unlock: `TlpMode::Flit` no longer returns `NotImplemented`; instead calls
+//   `TlpPacket::new_flit(bytes)` which uses FlitDW0 + OHC parser.
+// ============================================================================
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_end_to_end_mrd32_min() {
+    todo!(
+        "TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap()
+         → get_flit_type() == FlitTlpType::MemRead32
+         → get_data() is empty (read request, no payload)"
+    );
+}
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_end_to_end_mwr32_min() {
+    todo!(
+        "TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap()
+         → get_flit_type() == FlitTlpType::MemWrite32
+         → get_data() == [0xDE, 0xAD, 0xBE, 0xEF]"
+    );
+}
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_end_to_end_cas32() {
+    todo!(
+        "TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap()
+         → flit type == FlitTlpType::CompareSwap32
+         → payload == [0x11,0x11,0x11,0x11, 0x22,0x22,0x22,0x22]"
+    );
+}
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_end_to_end_dmwr32() {
+    todo!(
+        "TlpPacket::new(FM_DMWR32.to_vec(), TlpMode::Flit).unwrap()
+         → flit type == FlitTlpType::DeferrableMemWrite32
+         → payload == [0xC0, 0xFF, 0xEE, 0x00]"
+    );
+}
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_end_to_end_uiomwr64() {
+    todo!(
+        "TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap()
+         → flit type == FlitTlpType::UioMemWrite
+         → payload == [0x11,0x22,0x33,0x44, 0x55,0x66,0x77,0x88]"
+    );
+}
+
+#[test]
+#[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
+fn flit_t5_nop_has_no_data() {
+    todo!(
+        "TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap()
+         → flit type == FlitTlpType::Nop
+         → get_data().is_empty()"
+    );
+}

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -336,6 +336,27 @@ fn flit_t2_nop_sizes() {
     assert_eq!(dw0.total_bytes(), 4); // 1 DW header, no payload
 }
 
+// Length=0 encodes 1024 DW per PCIe spec — not "0 DW"
+#[test]
+fn flit_t2_total_bytes_length_zero_encodes_1024dw() {
+    // MWr32 (write, so it has payload) with Length=0 → 1024 DW = 4096 bytes payload
+    // DW0: type=0x40 (MemWrite32), ohc=0, length=0
+    let dw0 = FlitDW0::from_dw0(&[0x40, 0x00, 0x00, 0x00]).unwrap();
+    assert_eq!(dw0.length, 0);
+    // 3 DW base header + 1024 DW payload = 1027 DW = 4108 bytes
+    assert_eq!(dw0.total_bytes(), 3 * 4 + 1024 * 4);
+}
+
+#[test]
+fn flit_t2_total_bytes_length_zero_read_still_no_payload() {
+    // Read requests carry no payload even with length=0 encoding (which means 1024 DW)
+    // DW0: type=0x03 (MemRead32), ohc=0, length=0
+    let dw0 = FlitDW0::from_dw0(&[0x03, 0x00, 0x00, 0x00]).unwrap();
+    assert_eq!(dw0.length, 0);
+    // 3 DW base header, no payload (read request)
+    assert_eq!(dw0.total_bytes(), 3 * 4);
+}
+
 #[test]
 fn flit_t2_mrd32_min_sizes() {
     let dw0 = FlitDW0::from_dw0(&FM_MRD32_MIN).unwrap();

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -656,3 +656,35 @@ fn flit_t5_nonflit_packet_get_flit_type_returns_none() {
     let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x01], TlpMode::NonFlit).unwrap();
     assert_eq!(pkt.get_flit_type(), None);
 }
+
+// ============================================================================
+// Tier 5 atomic operand value verification
+// Verifies the actual operand bytes in FM_FETCHADD32 and FM_CAS32 are correct.
+// Note: new_atomic_req() requires NonFlit packets; here we verify operand bytes
+// directly from data() since flit mode doesn't yet expose an atomic parser.
+// ============================================================================
+
+#[test]
+fn flit_t5_fetchadd32_operand_value_in_payload() {
+    // FM_FETCHADD32 operand = 0x01000000 (comment says "Operand = 0x01000000")
+    // Verify: parse the flit packet and check that data() contains the operand bytes
+    let pkt = TlpPacket::new(FM_FETCHADD32.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::FetchAdd32));
+    // Payload = 3 DW header consumed, remaining = [0x01, 0x00, 0x00, 0x00]
+    assert_eq!(pkt.data().len(), 4, "FetchAdd32 has 1 DW operand");
+    let operand = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
+    assert_eq!(operand, 0x01000000, "FM_FETCHADD32 addend should be 0x01000000");
+}
+
+#[test]
+fn flit_t5_cas32_operand_values_in_payload() {
+    // FM_CAS32: Compare=0x11111111, Swap=0x22222222 (as documented in the constant)
+    let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
+    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::CompareSwap32));
+    // Payload = 3 DW header consumed, remaining = 8 bytes (compare + swap)
+    assert_eq!(pkt.data().len(), 8, "CAS32 has 2 DW payload (compare + swap)");
+    let compare = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
+    let swap    = u32::from_be_bytes([pkt.data()[4], pkt.data()[5], pkt.data()[6], pkt.data()[7]]);
+    assert_eq!(compare, 0x11111111, "FM_CAS32 compare operand");
+    assert_eq!(swap,    0x22222222, "FM_CAS32 swap operand");
+}

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -169,21 +169,28 @@ pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
 ];
 
 // ============================================================================
-// Tier 0 — Current stub behavior
+// Tier 0 — Regression guards
 //
-// These tests PASS TODAY and act as permanent regression guards.
+// These tests verify the core flit parsing entry points and two
+// parser-driven correctness checks for all FM_* byte-vector constants.
+//
+// Note: `TlpPacketHeader::new(Flit)` intentionally remains `NotImplemented` —
+// the flit header format is fundamentally different from non-flit DW0 and
+// a separate parser path has not been implemented for `TlpPacketHeader`.
 // ============================================================================
 
 #[test]
 fn flit_packet_new_succeeds_for_valid_flit() {
-    // TlpMode::Flit is now implemented -- MRd32 flit (3 DW header, no payload)
+    // TlpMode::Flit pipeline: MRd32 (3 DW base header, no payload despite Length=1)
     let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
-    assert!(pkt.data().is_empty()); // read request, no payload
+    assert!(pkt.data().is_empty()); // read request — no payload in the request packet
 }
 
 #[test]
 fn flit_header_new_returns_not_implemented() {
+    // TlpPacketHeader::new() with Flit intentionally returns NotImplemented.
+    // Flit DW0 uses a flat 8-bit type code incompatible with TlpHeader bitfield.
     let bytes = FM_MRD32_MIN.to_vec();
     assert_eq!(
         TlpPacketHeader::new(bytes, TlpMode::Flit).err().unwrap(),

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -191,56 +191,55 @@ fn flit_header_new_returns_not_implemented() {
     );
 }
 
+/// Parser-driven check: every FM_* constant decodes to the expected FlitTlpType.
+/// Unlike asserting FM_NOP[0] == 0x00 (which only checks a constant against itself),
+/// this test actually exercises the library's type-decode path.
 #[test]
-fn flit_byte_vectors_have_correct_sizes() {
-    assert_eq!(FM_NOP.len(),                 4);
-    assert_eq!(FM_MRD32_MIN.len(),          12);
-    assert_eq!(FM_MRD32_A1_PASID.len(),     16);
-    assert_eq!(FM_MWR32_MIN.len(),          16);
-    assert_eq!(FM_MWR32_PARTIAL_A1.len(),   20);
-    assert_eq!(FM_IOWR_A2.len(),            20);
-    assert_eq!(FM_CFGWR0_A3.len(),          20);
-    assert_eq!(FM_UIOMRD64_MIN.len(),       16);
-    assert_eq!(FM_UIOMWR64_MIN.len(),       24);
-    assert_eq!(FM_MSG_TO_RC.len(),          12);
-    assert_eq!(FM_MSGD_TO_RC.len(),         16);
-    assert_eq!(FM_FETCHADD32.len(),         16);
-    assert_eq!(FM_CAS32.len(),              20);
-    assert_eq!(FM_DMWR32.len(),             16);
-    assert_eq!(FM_STREAM_FRAGMENT_0.len(),  48);
-    assert_eq!(FM_LOCAL_PREFIX_ONLY.len(),   4);
+fn flit_all_fm_vectors_parse_to_expected_type() {
+    let cases: &[(&[u8], FlitTlpType)] = &[
+        (&FM_NOP,               FlitTlpType::Nop),
+        (&FM_MRD32_MIN,         FlitTlpType::MemRead32),
+        (&FM_MRD32_A1_PASID,    FlitTlpType::MemRead32),
+        (&FM_MWR32_MIN,         FlitTlpType::MemWrite32),
+        (&FM_MWR32_PARTIAL_A1,  FlitTlpType::MemWrite32),
+        (&FM_IOWR_A2,           FlitTlpType::IoWrite),
+        (&FM_CFGWR0_A3,         FlitTlpType::CfgWrite0),
+        (&FM_UIOMRD64_MIN,      FlitTlpType::UioMemRead),
+        (&FM_UIOMWR64_MIN,      FlitTlpType::UioMemWrite),
+        (&FM_MSG_TO_RC,         FlitTlpType::MsgToRc),
+        (&FM_MSGD_TO_RC,        FlitTlpType::MsgDToRc),
+        (&FM_FETCHADD32,        FlitTlpType::FetchAdd32),
+        (&FM_CAS32,             FlitTlpType::CompareSwap32),
+        (&FM_DMWR32,            FlitTlpType::DeferrableMemWrite32),
+        (&FM_LOCAL_PREFIX_ONLY, FlitTlpType::LocalTlpPrefix),
+    ];
+    for (bytes, expected) in cases {
+        let dw0 = FlitDW0::from_dw0(bytes)
+            .unwrap_or_else(|e| panic!("FM_* failed to parse: {:?} (byte0={:#04x})", e, bytes[0]));
+        assert_eq!(dw0.tlp_type, *expected,
+            "byte0={:#04x} decoded to {:?}, expected {:?}", bytes[0], dw0.tlp_type, expected);
+    }
 }
 
+/// Parser-driven OHC check: every FM_* constant decodes the OHC presence bitmap correctly.
 #[test]
-fn flit_dw0_type_bytes_are_correct() {
-    assert_eq!(FM_NOP[0],               0x00, "FM_NOP type");
-    assert_eq!(FM_MRD32_MIN[0],         0x03, "FM_MRD32_MIN type");
-    assert_eq!(FM_MRD32_A1_PASID[0],    0x03, "FM_MRD32_A1_PASID type");
-    assert_eq!(FM_MWR32_MIN[0],         0x40, "FM_MWR32_MIN type");
-    assert_eq!(FM_MWR32_PARTIAL_A1[0],  0x40, "FM_MWR32_PARTIAL_A1 type");
-    assert_eq!(FM_IOWR_A2[0],           0x42, "FM_IOWR_A2 type");
-    assert_eq!(FM_CFGWR0_A3[0],         0x44, "FM_CFGWR0_A3 type");
-    assert_eq!(FM_UIOMRD64_MIN[0],      0x22, "FM_UIOMRD64_MIN type");
-    assert_eq!(FM_UIOMWR64_MIN[0],      0x61, "FM_UIOMWR64_MIN type");
-    assert_eq!(FM_MSG_TO_RC[0],         0x30, "FM_MSG_TO_RC type");
-    assert_eq!(FM_MSGD_TO_RC[0],        0x70, "FM_MSGD_TO_RC type");
-    assert_eq!(FM_FETCHADD32[0],        0x4C, "FM_FETCHADD32 type");
-    assert_eq!(FM_CAS32[0],             0x4E, "FM_CAS32 type");
-    assert_eq!(FM_DMWR32[0],            0x5B, "FM_DMWR32 type");
-    assert_eq!(FM_LOCAL_PREFIX_ONLY[0], 0x8D, "FM_LOCAL_PREFIX_ONLY type");
-}
-
-#[test]
-fn flit_dw0_ohc_bytes_are_correct() {
-    let ohc = |b: u8| b & 0x1F;
-
-    assert_eq!(ohc(FM_NOP[1]),              0x00, "FM_NOP ohc");
-    assert_eq!(ohc(FM_MRD32_MIN[1]),        0x00, "FM_MRD32_MIN ohc");
-    assert_eq!(ohc(FM_MWR32_MIN[1]),        0x00, "FM_MWR32_MIN ohc");
-    assert_eq!(ohc(FM_MRD32_A1_PASID[1]),   0x01, "FM_MRD32_A1_PASID ohc-A1");
-    assert_eq!(ohc(FM_MWR32_PARTIAL_A1[1]), 0x01, "FM_MWR32_PARTIAL_A1 ohc-A1");
-    assert_eq!(ohc(FM_IOWR_A2[1]),          0x01, "FM_IOWR_A2 ohc-A2");
-    assert_eq!(ohc(FM_CFGWR0_A3[1]),        0x01, "FM_CFGWR0_A3 ohc-A3");
+fn flit_all_fm_vectors_parse_with_correct_ohc() {
+    // (vector, expected OHC bitmap value)
+    let cases: &[(&[u8], u8, &str)] = &[
+        (&FM_NOP,               0, "FM_NOP"),
+        (&FM_MRD32_MIN,         0, "FM_MRD32_MIN"),
+        (&FM_MWR32_MIN,         0, "FM_MWR32_MIN"),
+        (&FM_MRD32_A1_PASID,    1, "FM_MRD32_A1_PASID"),   // OHC-A1
+        (&FM_MWR32_PARTIAL_A1,  1, "FM_MWR32_PARTIAL_A1"), // OHC-A1
+        (&FM_IOWR_A2,           1, "FM_IOWR_A2"),           // OHC-A2
+        (&FM_CFGWR0_A3,         1, "FM_CFGWR0_A3"),         // OHC-A3
+    ];
+    for (bytes, expected_ohc, name) in cases {
+        let dw0 = FlitDW0::from_dw0(bytes).unwrap();
+        assert_eq!(dw0.ohc, *expected_ohc, "{} ohc mismatch", name);
+        assert_eq!(dw0.ohc_count(), (*expected_ohc).count_ones() as u8,
+            "{} ohc_count mismatch", name);
+    }
 }
 
 // ============================================================================

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -179,7 +179,7 @@ fn flit_packet_new_succeeds_for_valid_flit() {
     // TlpMode::Flit is now implemented -- MRd32 flit (3 DW header, no payload)
     let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
-    assert!(pkt.get_data().is_empty()); // read request, no payload
+    assert!(pkt.data().is_empty()); // read request, no payload
 }
 
 #[test]
@@ -602,7 +602,7 @@ fn flit_t5_end_to_end_mrd32_min() {
     // MRd32 flit: 3 DW base header, no payload despite Length=1
     let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
-    assert!(pkt.get_data().is_empty());
+    assert!(pkt.data().is_empty());
 }
 
 #[test]
@@ -610,7 +610,7 @@ fn flit_t5_end_to_end_mwr32_min() {
     // MWr32 flit: 3 DW header + 1 DW payload
     let pkt = TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
-    assert_eq!(pkt.get_data(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    assert_eq!(pkt.data(), [0xDE, 0xAD, 0xBE, 0xEF]);
 }
 
 #[test]
@@ -618,7 +618,7 @@ fn flit_t5_end_to_end_cas32() {
     // CAS32 flit: 3 DW header + 2 DW payload (compare + swap)
     let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::CompareSwap32));
-    assert_eq!(pkt.get_data(), vec![
+    assert_eq!(pkt.data(), [
         0x11, 0x11, 0x11, 0x11, // compare
         0x22, 0x22, 0x22, 0x22, // swap
     ]);
@@ -629,7 +629,7 @@ fn flit_t5_end_to_end_dmwr32() {
     // DMWr32 flit: 3 DW header + 1 DW payload
     let pkt = TlpPacket::new(FM_DMWR32.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::DeferrableMemWrite32));
-    assert_eq!(pkt.get_data(), vec![0xC0, 0xFF, 0xEE, 0x00]);
+    assert_eq!(pkt.data(), [0xC0, 0xFF, 0xEE, 0x00]);
 }
 
 #[test]
@@ -637,7 +637,7 @@ fn flit_t5_end_to_end_uiomwr64() {
     // UIOMWr64 flit: 4 DW header + 2 DW payload
     let pkt = TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::UioMemWrite));
-    assert_eq!(pkt.get_data(), vec![
+    assert_eq!(pkt.data(), [
         0x11, 0x22, 0x33, 0x44,
         0x55, 0x66, 0x77, 0x88,
     ]);
@@ -648,7 +648,7 @@ fn flit_t5_nop_has_no_data() {
     // NOP flit: 1 DW header, no payload
     let pkt = TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
-    assert!(pkt.get_data().is_empty());
+    assert!(pkt.data().is_empty());
 }
 
 #[test]

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -8,8 +8,8 @@
 //! | Tier | Status | Unlock condition |
 //! |------|--------|-----------------|
 //! | 0 | ✅ passes today | N/A — permanent stub regression guard |
-//! | 1 | `#[ignore]` | `FlitDW0` struct + `flit_dw0_from_bytes()` |
-//! | 2 | `#[ignore]` | `FlitTlpType` enum + header-size table |
+//! | 1 | ✅ passes today | `FlitDW0::from_dw0()` ← **implemented** |
+//! | 2 | ✅ passes today | `FlitTlpType::base_header_dw()` ← **implemented** |
 //! | 3 | `#[ignore]` | OHC parser + `TlpError::MissingMandatoryOhc` |
 //! | 4 | `#[ignore]` | `FlitStreamWalker` / stream iterator |
 //! | 5 | `#[ignore]` | `TlpPacket::new_flit()` fully wired |
@@ -172,8 +172,6 @@ pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
 // Tier 0 — Current stub behavior
 //
 // These tests PASS TODAY and act as permanent regression guards.
-// They verify that TlpMode::Flit correctly returns NotImplemented until
-// the flit parser is implemented.
 // ============================================================================
 
 #[test]
@@ -196,7 +194,6 @@ fn flit_header_new_returns_not_implemented() {
 
 #[test]
 fn flit_byte_vectors_have_correct_sizes() {
-    // Compile-time size sanity check — no parser required.
     assert_eq!(FM_NOP.len(),                 4);
     assert_eq!(FM_MRD32_MIN.len(),          12);
     assert_eq!(FM_MRD32_A1_PASID.len(),     16);
@@ -217,7 +214,6 @@ fn flit_byte_vectors_have_correct_sizes() {
 
 #[test]
 fn flit_dw0_type_bytes_are_correct() {
-    // Verify type code (byte 0) for each vector without any parser.
     assert_eq!(FM_NOP[0],               0x00, "FM_NOP type");
     assert_eq!(FM_MRD32_MIN[0],         0x03, "FM_MRD32_MIN type");
     assert_eq!(FM_MRD32_A1_PASID[0],    0x03, "FM_MRD32_A1_PASID type");
@@ -237,173 +233,240 @@ fn flit_dw0_type_bytes_are_correct() {
 
 #[test]
 fn flit_dw0_ohc_bytes_are_correct() {
-    // Verify OHC presence flag (byte 1, bits[4:0]) for vectors with OHC.
-    let ohc = |b: u8| b & 0x1F; // lower 5 bits = OHC field
+    let ohc = |b: u8| b & 0x1F;
 
-    // No OHC
     assert_eq!(ohc(FM_NOP[1]),              0x00, "FM_NOP ohc");
     assert_eq!(ohc(FM_MRD32_MIN[1]),        0x00, "FM_MRD32_MIN ohc");
     assert_eq!(ohc(FM_MWR32_MIN[1]),        0x00, "FM_MWR32_MIN ohc");
-    // OHC-A1 present (bit 0 set)
     assert_eq!(ohc(FM_MRD32_A1_PASID[1]),   0x01, "FM_MRD32_A1_PASID ohc-A1");
     assert_eq!(ohc(FM_MWR32_PARTIAL_A1[1]), 0x01, "FM_MWR32_PARTIAL_A1 ohc-A1");
-    // OHC-A2/A3 present (bit 0 set via OHC-A presence)
     assert_eq!(ohc(FM_IOWR_A2[1]),          0x01, "FM_IOWR_A2 ohc-A2");
     assert_eq!(ohc(FM_CFGWR0_A3[1]),        0x01, "FM_CFGWR0_A3 ohc-A3");
 }
 
 // ============================================================================
-// Tier 1 — Flit DW0 field extraction
-//
-// #[ignore] — pending: FlitDW0 struct and flit_dw0_from_bytes() in src/lib.rs
-//
-// Unlock: add `pub fn flit_dw0_from_bytes(b: &[u8]) -> Result<FlitDW0, TlpError>`
-//         and `pub struct FlitDW0 { tlp_type, tc, ohc, ts, attr, length }`
+// Tier 1 — Flit DW0 field extraction (FlitDW0::from_dw0)
 // ============================================================================
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_nop_dw0_fields() {
-    todo!("FlitDW0::from_dw0(FM_NOP) → type=Nop, tc=0, ohc=0, length=0");
+    let dw0 = FlitDW0::from_dw0(&FM_NOP).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::Nop);
+    assert_eq!(dw0.tc,     0);
+    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.ts,     0);
+    assert_eq!(dw0.attr,   0);
+    assert_eq!(dw0.length, 0);
 }
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_mrd32_dw0_fields() {
-    todo!("FlitDW0::from_dw0(FM_MRD32_MIN) → type=MemRead32, tc=0, ohc=0, length=1");
+    // FM_MRD32_MIN = [0x03, 0x00, 0x00, 0x01]
+    let dw0 = FlitDW0::from_dw0(&FM_MRD32_MIN).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::MemRead32);
+    assert_eq!(dw0.tc,     0);
+    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.length, 1); // Length field = 1 DW (but no actual payload — it's a read)
 }
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_mrd32_a1_dw0_ohc_present() {
-    todo!("FlitDW0::from_dw0(FM_MRD32_A1_PASID) → ohc=0x01 (OHC-A1 bit set)");
+    // FM_MRD32_A1_PASID = [0x03, 0x01, 0x00, 0x01]
+    let dw0 = FlitDW0::from_dw0(&FM_MRD32_A1_PASID).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::MemRead32);
+    assert_eq!(dw0.ohc, 0x01); // OHC-A1 bit set
+    assert_eq!(dw0.ohc_count(), 1);
+    assert_eq!(dw0.length, 1);
 }
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_mwr32_dw0_fields() {
-    todo!("FlitDW0::from_dw0(FM_MWR32_MIN) → type=MemWrite32, length=1");
+    // FM_MWR32_MIN = [0x40, 0x00, 0x00, 0x01]
+    let dw0 = FlitDW0::from_dw0(&FM_MWR32_MIN).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::MemWrite32);
+    assert_eq!(dw0.tc,     0);
+    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.length, 1);
 }
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_uiomrd64_dw0_fields() {
-    todo!("FlitDW0::from_dw0(FM_UIOMRD64_MIN) → type=UioMemRead, length=2");
+    // FM_UIOMRD64_MIN = [0x22, 0x00, 0x00, 0x02]
+    let dw0 = FlitDW0::from_dw0(&FM_UIOMRD64_MIN).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::UioMemRead);
+    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.length, 2);
 }
 
 #[test]
-#[ignore = "pending: FlitDW0 struct not yet implemented (Tier 1)"]
 fn flit_t1_cas32_dw0_length_is_2() {
-    todo!("FlitDW0::from_dw0(FM_CAS32) → length=2 (2 DW payload: compare + swap)");
+    // FM_CAS32 = [0x4E, 0x00, 0x00, 0x02] — 2 DW payload (compare + swap)
+    let dw0 = FlitDW0::from_dw0(&FM_CAS32).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::CompareSwap32);
+    assert_eq!(dw0.length, 2);
+}
+
+#[test]
+fn flit_t1_unknown_type_returns_invalid_type_error() {
+    // Type code 0xFF is not in the known table
+    let bad_type = [0xFF, 0x00, 0x00, 0x00];
+    assert_eq!(
+        FlitDW0::from_dw0(&bad_type).err().unwrap(),
+        TlpError::InvalidType
+    );
+}
+
+#[test]
+fn flit_t1_short_slice_returns_invalid_length_error() {
+    assert_eq!(
+        FlitDW0::from_dw0(&[0x03, 0x00, 0x00]).err().unwrap(),
+        TlpError::InvalidLength
+    );
 }
 
 // ============================================================================
-// Tier 2 — Per-vector header + size validation
-//
-// #[ignore] — pending: FlitTlpType enum and type-to-header-size table
-//
-// Unlock: add `pub enum FlitTlpType` and a function to compute:
-//   header_bytes = (base_header_dw(type) + ohc_count) * 4
-//   total_bytes  = header_bytes + length_dw * 4
+// Tier 2 — Per-vector header + total size validation
 // ============================================================================
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_nop_sizes() {
-    todo!(
-        "FM_NOP: FlitTlpType::Nop, base_header=1DW, ohc=0, payload=0DW, total=4B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_NOP).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::Nop);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 1);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.total_bytes(), 4); // 1 DW header, no payload
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_mrd32_min_sizes() {
-    todo!(
-        "FM_MRD32_MIN: FlitTlpType::MemRead32, base=3DW, ohc=0, payload=0DW (read!), total=12B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_MRD32_MIN).unwrap();
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 1);
+    // Read request: no payload bytes even though Length=1
+    assert_eq!(dw0.total_bytes(), 12);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_mrd32_a1_sizes() {
-    todo!(
-        "FM_MRD32_A1_PASID: base=3DW, ohc=1DW, payload=0DW, total=16B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_MRD32_A1_PASID).unwrap();
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 1); // OHC-A1 adds 1 DW
+    // Read: no payload. Total = (3+1)*4 = 16
+    assert_eq!(dw0.total_bytes(), 16);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_mwr32_min_sizes() {
-    todo!(
-        "FM_MWR32_MIN: base=3DW, ohc=0, payload=1DW, total=16B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_MWR32_MIN).unwrap();
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 1);
+    // Write: 1 DW payload. Total = 3*4 + 1*4 = 16
+    assert_eq!(dw0.total_bytes(), 16);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_mwr32_partial_a1_sizes() {
-    todo!(
-        "FM_MWR32_PARTIAL_A1: base=3DW, ohc=1DW, payload=1DW, total=20B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_MWR32_PARTIAL_A1).unwrap();
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 1);
+    assert_eq!(dw0.length, 1);
+    // Total = (3+1)*4 + 1*4 = 20
+    assert_eq!(dw0.total_bytes(), 20);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_iowr_a2_sizes() {
-    todo!(
-        "FM_IOWR_A2: FlitTlpType::IoWrite, base=3DW, ohc=1DW, payload=1DW, total=20B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_IOWR_A2).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::IoWrite);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 1);
+    assert_eq!(dw0.length, 1);
+    assert_eq!(dw0.total_bytes(), 20);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_cfgwr0_a3_sizes() {
-    todo!(
-        "FM_CFGWR0_A3: FlitTlpType::CfgWrite0, base=3DW, ohc=1DW, payload=1DW, total=20B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_CFGWR0_A3).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::CfgWrite0);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 1);
+    assert_eq!(dw0.length, 1);
+    assert_eq!(dw0.total_bytes(), 20);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_uiomrd64_sizes() {
-    todo!(
-        "FM_UIOMRD64_MIN: FlitTlpType::UioMemRead, base=4DW, ohc=0, payload=0DW, total=16B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_UIOMRD64_MIN).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::UioMemRead);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 4); // 4DW header (64-bit address)
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 2);
+    // Read: no payload. Total = 4*4 = 16
+    assert_eq!(dw0.total_bytes(), 16);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_uiomwr64_sizes() {
-    todo!(
-        "FM_UIOMWR64_MIN: FlitTlpType::UioMemWrite, base=4DW, ohc=0, payload=2DW, total=24B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_UIOMWR64_MIN).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::UioMemWrite);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 4);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 2);
+    // Write: 2 DW payload. Total = 4*4 + 2*4 = 24
+    assert_eq!(dw0.total_bytes(), 24);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_cas32_sizes() {
-    todo!(
-        "FM_CAS32: FlitTlpType::CompareSwap32, base=3DW, ohc=0, payload=2DW, total=20B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_CAS32).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::CompareSwap32);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 2);
+    // 2 DW payload (compare + swap). Total = 3*4 + 2*4 = 20
+    assert_eq!(dw0.total_bytes(), 20);
 }
 
 #[test]
-#[ignore = "pending: FlitTlpType enum not yet implemented (Tier 2)"]
 fn flit_t2_dmwr32_type_and_sizes() {
-    todo!(
-        "FM_DMWR32: FlitTlpType::DeferrableMemWrite32, base=3DW, ohc=0, payload=1DW, total=16B"
-    );
+    let dw0 = FlitDW0::from_dw0(&FM_DMWR32).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::DeferrableMemWrite32);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 3);
+    assert_eq!(dw0.ohc_count(), 0);
+    assert_eq!(dw0.length, 1);
+    assert_eq!(dw0.total_bytes(), 16);
+}
+
+#[test]
+fn flit_t2_read_request_predicate() {
+    // MemRead32 and UioMemRead are read requests — no payload
+    assert!(FlitTlpType::MemRead32.is_read_request());
+    assert!(FlitTlpType::UioMemRead.is_read_request());
+
+    // Writes and atomics are NOT read requests
+    assert!(!FlitTlpType::MemWrite32.is_read_request());
+    assert!(!FlitTlpType::IoWrite.is_read_request());
+    assert!(!FlitTlpType::CfgWrite0.is_read_request());
+    assert!(!FlitTlpType::FetchAdd32.is_read_request());
+    assert!(!FlitTlpType::CompareSwap32.is_read_request());
+    assert!(!FlitTlpType::DeferrableMemWrite32.is_read_request());
+    assert!(!FlitTlpType::Nop.is_read_request());
+}
+
+#[test]
+fn flit_t2_local_prefix_base_header_is_1dw() {
+    let dw0 = FlitDW0::from_dw0(&FM_LOCAL_PREFIX_ONLY).unwrap();
+    assert_eq!(dw0.tlp_type, FlitTlpType::LocalTlpPrefix);
+    assert_eq!(dw0.tlp_type.base_header_dw(), 1);
+    assert_eq!(dw0.total_bytes(), 4);
 }
 
 // ============================================================================
 // Tier 3 — OHC field parsing and mandatory OHC validation
 //
 // #[ignore] — pending: OHC parser + TlpError::MissingMandatoryOhc variant
-//
-// Unlock:
-//   - `pub struct FlitOhc { a1: Option<OhcA1>, ... }`
-//   - `TlpError::MissingMandatoryOhc`
-//   - Parser enforces: IO requires OHC-A2, Config requires OHC-A3
 // ============================================================================
 
 #[test]
@@ -436,8 +499,6 @@ fn flit_t3_iowr_a2_mandatory_ohc_present() {
 #[test]
 #[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_iowr_missing_mandatory_ohc_a2() {
-    // Negative test: FM_IOWR_A2 with byte1 cleared (no OHC declared)
-    // Expected: Err(TlpError::MissingMandatoryOhc)
     let mut bad = FM_IOWR_A2.to_vec();
     bad[1] = 0x00; // clear OHC flags — mandatory OHC-A2 missing
     todo!(
@@ -457,7 +518,6 @@ fn flit_t3_cfgwr0_a3_mandatory_ohc_present() {
 #[test]
 #[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_cfgwr_missing_mandatory_ohc_a3() {
-    // Negative test: FM_CFGWR0_A3 with byte1 cleared
     let mut bad = FM_CFGWR0_A3.to_vec();
     bad[1] = 0x00; // clear OHC flags — mandatory OHC-A3 missing
     todo!(
@@ -468,21 +528,12 @@ fn flit_t3_cfgwr_missing_mandatory_ohc_a3() {
 // ============================================================================
 // Tier 4 — Packed stream walking
 //
-// #[ignore] — pending: FlitStreamWalker or equivalent iterator in src/lib.rs
-//
-// Unlock: `pub struct FlitStreamWalker<'a>` or `flit_stream_iter(bytes: &[u8])`
-//   yields `(offset: usize, FlitTlpType, total_size: usize)` for each TLP
+// #[ignore] — pending: FlitStreamWalker not yet implemented
 // ============================================================================
 
 #[test]
 #[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
 fn flit_t4_stream_fragment_0_offsets() {
-    // FM_STREAM_FRAGMENT_0 contains 4 back-to-back TLPs:
-    //   offset  0 → NOP,     size  4B
-    //   offset  4 → MRd32,   size 12B
-    //   offset 16 → MWr32,   size 16B
-    //   offset 32 → UIOMRd,  size 16B
-    //   offset 48 → end
     todo!(
         "let walker = FlitStreamWalker::new(&FM_STREAM_FRAGMENT_0);
          let entries: Vec<_> = walker.collect();
@@ -497,7 +548,6 @@ fn flit_t4_stream_fragment_0_offsets() {
 #[test]
 #[ignore = "pending: FlitStreamWalker not yet implemented (Tier 4)"]
 fn flit_t4_stream_truncated_payload_error() {
-    // FM_UIOMWR64_MIN with last byte removed → total-size check must fail
     let mut truncated = FM_UIOMWR64_MIN.to_vec();
     truncated.pop();
     todo!(
@@ -508,10 +558,7 @@ fn flit_t4_stream_truncated_payload_error() {
 // ============================================================================
 // Tier 5 — End-to-end TlpMode::Flit pipeline
 //
-// #[ignore] — pending: TlpPacket::new_flit() fully wired in src/lib.rs
-//
-// Unlock: `TlpMode::Flit` no longer returns `NotImplemented`; instead calls
-//   `TlpPacket::new_flit(bytes)` which uses FlitDW0 + OHC parser.
+// #[ignore] — pending: TlpPacket::new_flit() fully wired
 // ============================================================================
 
 #[test]
@@ -519,7 +566,6 @@ fn flit_t4_stream_truncated_payload_error() {
 fn flit_t5_end_to_end_mrd32_min() {
     todo!(
         "TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap()
-         → get_flit_type() == FlitTlpType::MemRead32
          → get_data() is empty (read request, no payload)"
     );
 }
@@ -529,7 +575,6 @@ fn flit_t5_end_to_end_mrd32_min() {
 fn flit_t5_end_to_end_mwr32_min() {
     todo!(
         "TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap()
-         → get_flit_type() == FlitTlpType::MemWrite32
          → get_data() == [0xDE, 0xAD, 0xBE, 0xEF]"
     );
 }
@@ -538,9 +583,7 @@ fn flit_t5_end_to_end_mwr32_min() {
 #[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_cas32() {
     todo!(
-        "TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap()
-         → flit type == FlitTlpType::CompareSwap32
-         → payload == [0x11,0x11,0x11,0x11, 0x22,0x22,0x22,0x22]"
+        "payload == [0x11,0x11,0x11,0x11, 0x22,0x22,0x22,0x22]"
     );
 }
 
@@ -548,9 +591,7 @@ fn flit_t5_end_to_end_cas32() {
 #[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_dmwr32() {
     todo!(
-        "TlpPacket::new(FM_DMWR32.to_vec(), TlpMode::Flit).unwrap()
-         → flit type == FlitTlpType::DeferrableMemWrite32
-         → payload == [0xC0, 0xFF, 0xEE, 0x00]"
+        "payload == [0xC0, 0xFF, 0xEE, 0x00]"
     );
 }
 
@@ -558,9 +599,7 @@ fn flit_t5_end_to_end_dmwr32() {
 #[ignore = "pending: TlpMode::Flit not yet implemented (Tier 5)"]
 fn flit_t5_end_to_end_uiomwr64() {
     todo!(
-        "TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap()
-         → flit type == FlitTlpType::UioMemWrite
-         → payload == [0x11,0x22,0x33,0x44, 0x55,0x66,0x77,0x88]"
+        "payload == [0x11,0x22,0x33,0x44, 0x55,0x66,0x77,0x88]"
     );
 }
 
@@ -569,7 +608,6 @@ fn flit_t5_end_to_end_uiomwr64() {
 fn flit_t5_nop_has_no_data() {
     todo!(
         "TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap()
-         → flit type == FlitTlpType::Nop
          → get_data().is_empty()"
     );
 }

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -31,142 +31,91 @@ use rtlp_lib::*;
 // ============================================================================
 
 /// Flit-mode NOP. Smallest possible header-base object (1 DW, no payload).
-pub const FM_NOP: [u8; 4] = [
-    0x00, 0x00, 0x00, 0x00,
-];
+pub const FM_NOP: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
 
 /// Minimal 32-bit Memory Read Request. Length=1 DW, no OHC, no payload.
 pub const FM_MRD32_MIN: [u8; 12] = [
-    0x03, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
+    0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
 /// 32-bit Memory Read Request with OHC-A1 carrying PASID=0x12345, fdwbe=0xF, ldwbe=0x0.
 pub const FM_MRD32_A1_PASID: [u8; 16] = [
-    0x03, 0x01, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x01, 0x23, 0x45, 0x0F,
+    0x03, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x0F,
 ];
 
 /// Minimal 32-bit Memory Write Request. Length=1 DW, no OHC, payload=0xDEADBEEF.
 pub const FM_MWR32_MIN: [u8; 16] = [
-    0x40, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0xDE, 0xAD, 0xBE, 0xEF,
+    0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF,
 ];
 
 /// 32-bit Memory Write Request with OHC-A1. fdwbe=0x3 (partial-byte write).
 pub const FM_MWR32_PARTIAL_A1: [u8; 20] = [
-    0x40, 0x01, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x03,
+    0x40, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
     0xAA, 0xBB, 0xCC, 0xDD,
 ];
 
 /// I/O Write Request with mandatory OHC-A2. fdwbe=0xF.
 pub const FM_IOWR_A2: [u8; 20] = [
-    0x42, 0x01, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x0F,
+    0x42, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F,
     0x10, 0x20, 0x30, 0x40,
 ];
 
 /// Type0 Configuration Write Request with mandatory OHC-A3. fdwbe=0xF.
 pub const FM_CFGWR0_A3: [u8; 20] = [
-    0x44, 0x01, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x0F,
+    0x44, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F,
     0x44, 0x33, 0x22, 0x11,
 ];
 
 /// Minimal UIO Memory Read Request (PCIe 6.1+ UIO). 4 DW base header, Length=2 DW, no payload.
 pub const FM_UIOMRD64_MIN: [u8; 16] = [
-    0x22, 0x00, 0x00, 0x02,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
+    0x22, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
 /// Minimal UIO Memory Write Request (PCIe 6.1+ UIO). 4 DW base header, 2 DW payload.
 pub const FM_UIOMWR64_MIN: [u8; 24] = [
-    0x61, 0x00, 0x00, 0x02,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x11, 0x22, 0x33, 0x44,
-    0x55, 0x66, 0x77, 0x88,
+    0x61, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
 ];
 
 /// Message routed to RC, no data.
 pub const FM_MSG_TO_RC: [u8; 12] = [
-    0x30, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
+    0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
 /// Message with data, routed to RC.
 pub const FM_MSGD_TO_RC: [u8; 16] = [
-    0x70, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0xAA, 0x55, 0xAA, 0x55,
+    0x70, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0x55, 0xAA, 0x55,
 ];
 
 /// 32-bit FetchAdd AtomicOp Request. Operand = 0x01000000.
 pub const FM_FETCHADD32: [u8; 16] = [
-    0x4C, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x00, 0x00,
+    0x4C, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
 ];
 
 /// 32-bit Compare-and-Swap AtomicOp Request. Compare=0x11111111, Swap=0x22222222.
 pub const FM_CAS32: [u8; 20] = [
-    0x4E, 0x00, 0x00, 0x02,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x11, 0x11, 0x11, 0x11,
+    0x4E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11, 0x11,
     0x22, 0x22, 0x22, 0x22,
 ];
 
 /// 32-bit Deferrable Memory Write Request.
 pub const FM_DMWR32: [u8; 16] = [
-    0x5B, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0xC0, 0xFF, 0xEE, 0x00,
+    0x5B, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xFF, 0xEE, 0x00,
 ];
 
 /// Packed stream fragment: NOP + MRd32 + MWr32 + UIOMRd64 back-to-back.
 pub const FM_STREAM_FRAGMENT_0: [u8; 48] = [
     // NOP (4 bytes, offset 0)
-    0x00, 0x00, 0x00, 0x00,
-    // MRd32 (12 bytes, offset 4)
-    0x03, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, // MRd32 (12 bytes, offset 4)
+    0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     // MWr32 (16 bytes, offset 16)
-    0x40, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0xDE, 0xAD, 0xBE, 0xEF,
+    0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF,
     // UIOMRd64 (16 bytes, offset 32)
-    0x22, 0x00, 0x00, 0x02,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
+    0x22, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
 /// Local TLP Prefix token (Appendix A — not a standalone transaction).
-pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
-    0x8D, 0x00, 0x00, 0x00,
-];
+pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [0x8D, 0x00, 0x00, 0x00];
 
 // ============================================================================
 // Tier 0 — Regression guards
@@ -204,27 +153,30 @@ fn flit_header_new_returns_not_implemented() {
 #[test]
 fn flit_all_fm_vectors_parse_to_expected_type() {
     let cases: &[(&[u8], FlitTlpType)] = &[
-        (&FM_NOP,               FlitTlpType::Nop),
-        (&FM_MRD32_MIN,         FlitTlpType::MemRead32),
-        (&FM_MRD32_A1_PASID,    FlitTlpType::MemRead32),
-        (&FM_MWR32_MIN,         FlitTlpType::MemWrite32),
-        (&FM_MWR32_PARTIAL_A1,  FlitTlpType::MemWrite32),
-        (&FM_IOWR_A2,           FlitTlpType::IoWrite),
-        (&FM_CFGWR0_A3,         FlitTlpType::CfgWrite0),
-        (&FM_UIOMRD64_MIN,      FlitTlpType::UioMemRead),
-        (&FM_UIOMWR64_MIN,      FlitTlpType::UioMemWrite),
-        (&FM_MSG_TO_RC,         FlitTlpType::MsgToRc),
-        (&FM_MSGD_TO_RC,        FlitTlpType::MsgDToRc),
-        (&FM_FETCHADD32,        FlitTlpType::FetchAdd32),
-        (&FM_CAS32,             FlitTlpType::CompareSwap32),
-        (&FM_DMWR32,            FlitTlpType::DeferrableMemWrite32),
+        (&FM_NOP, FlitTlpType::Nop),
+        (&FM_MRD32_MIN, FlitTlpType::MemRead32),
+        (&FM_MRD32_A1_PASID, FlitTlpType::MemRead32),
+        (&FM_MWR32_MIN, FlitTlpType::MemWrite32),
+        (&FM_MWR32_PARTIAL_A1, FlitTlpType::MemWrite32),
+        (&FM_IOWR_A2, FlitTlpType::IoWrite),
+        (&FM_CFGWR0_A3, FlitTlpType::CfgWrite0),
+        (&FM_UIOMRD64_MIN, FlitTlpType::UioMemRead),
+        (&FM_UIOMWR64_MIN, FlitTlpType::UioMemWrite),
+        (&FM_MSG_TO_RC, FlitTlpType::MsgToRc),
+        (&FM_MSGD_TO_RC, FlitTlpType::MsgDToRc),
+        (&FM_FETCHADD32, FlitTlpType::FetchAdd32),
+        (&FM_CAS32, FlitTlpType::CompareSwap32),
+        (&FM_DMWR32, FlitTlpType::DeferrableMemWrite32),
         (&FM_LOCAL_PREFIX_ONLY, FlitTlpType::LocalTlpPrefix),
     ];
     for (bytes, expected) in cases {
         let dw0 = FlitDW0::from_dw0(bytes)
             .unwrap_or_else(|e| panic!("FM_* failed to parse: {:?} (byte0={:#04x})", e, bytes[0]));
-        assert_eq!(dw0.tlp_type, *expected,
-            "byte0={:#04x} decoded to {:?}, expected {:?}", bytes[0], dw0.tlp_type, expected);
+        assert_eq!(
+            dw0.tlp_type, *expected,
+            "byte0={:#04x} decoded to {:?}, expected {:?}",
+            bytes[0], dw0.tlp_type, expected
+        );
     }
 }
 
@@ -233,19 +185,23 @@ fn flit_all_fm_vectors_parse_to_expected_type() {
 fn flit_all_fm_vectors_parse_with_correct_ohc() {
     // (vector, expected OHC bitmap value)
     let cases: &[(&[u8], u8, &str)] = &[
-        (&FM_NOP,               0, "FM_NOP"),
-        (&FM_MRD32_MIN,         0, "FM_MRD32_MIN"),
-        (&FM_MWR32_MIN,         0, "FM_MWR32_MIN"),
-        (&FM_MRD32_A1_PASID,    1, "FM_MRD32_A1_PASID"),   // OHC-A1
-        (&FM_MWR32_PARTIAL_A1,  1, "FM_MWR32_PARTIAL_A1"), // OHC-A1
-        (&FM_IOWR_A2,           1, "FM_IOWR_A2"),           // OHC-A2
-        (&FM_CFGWR0_A3,         1, "FM_CFGWR0_A3"),         // OHC-A3
+        (&FM_NOP, 0, "FM_NOP"),
+        (&FM_MRD32_MIN, 0, "FM_MRD32_MIN"),
+        (&FM_MWR32_MIN, 0, "FM_MWR32_MIN"),
+        (&FM_MRD32_A1_PASID, 1, "FM_MRD32_A1_PASID"), // OHC-A1
+        (&FM_MWR32_PARTIAL_A1, 1, "FM_MWR32_PARTIAL_A1"), // OHC-A1
+        (&FM_IOWR_A2, 1, "FM_IOWR_A2"),               // OHC-A2
+        (&FM_CFGWR0_A3, 1, "FM_CFGWR0_A3"),           // OHC-A3
     ];
     for (bytes, expected_ohc, name) in cases {
         let dw0 = FlitDW0::from_dw0(bytes).unwrap();
         assert_eq!(dw0.ohc, *expected_ohc, "{} ohc mismatch", name);
-        assert_eq!(dw0.ohc_count(), (*expected_ohc).count_ones() as u8,
-            "{} ohc_count mismatch", name);
+        assert_eq!(
+            dw0.ohc_count(),
+            (*expected_ohc).count_ones() as u8,
+            "{} ohc_count mismatch",
+            name
+        );
     }
 }
 
@@ -257,10 +213,10 @@ fn flit_all_fm_vectors_parse_with_correct_ohc() {
 fn flit_t1_nop_dw0_fields() {
     let dw0 = FlitDW0::from_dw0(&FM_NOP).unwrap();
     assert_eq!(dw0.tlp_type, FlitTlpType::Nop);
-    assert_eq!(dw0.tc,     0);
-    assert_eq!(dw0.ohc,    0);
-    assert_eq!(dw0.ts,     0);
-    assert_eq!(dw0.attr,   0);
+    assert_eq!(dw0.tc, 0);
+    assert_eq!(dw0.ohc, 0);
+    assert_eq!(dw0.ts, 0);
+    assert_eq!(dw0.attr, 0);
     assert_eq!(dw0.length, 0);
 }
 
@@ -269,8 +225,8 @@ fn flit_t1_mrd32_dw0_fields() {
     // FM_MRD32_MIN = [0x03, 0x00, 0x00, 0x01]
     let dw0 = FlitDW0::from_dw0(&FM_MRD32_MIN).unwrap();
     assert_eq!(dw0.tlp_type, FlitTlpType::MemRead32);
-    assert_eq!(dw0.tc,     0);
-    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.tc, 0);
+    assert_eq!(dw0.ohc, 0);
     assert_eq!(dw0.length, 1); // Length field = 1 DW (but no actual payload — it's a read)
 }
 
@@ -289,8 +245,8 @@ fn flit_t1_mwr32_dw0_fields() {
     // FM_MWR32_MIN = [0x40, 0x00, 0x00, 0x01]
     let dw0 = FlitDW0::from_dw0(&FM_MWR32_MIN).unwrap();
     assert_eq!(dw0.tlp_type, FlitTlpType::MemWrite32);
-    assert_eq!(dw0.tc,     0);
-    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.tc, 0);
+    assert_eq!(dw0.ohc, 0);
     assert_eq!(dw0.length, 1);
 }
 
@@ -299,7 +255,7 @@ fn flit_t1_uiomrd64_dw0_fields() {
     // FM_UIOMRD64_MIN = [0x22, 0x00, 0x00, 0x02]
     let dw0 = FlitDW0::from_dw0(&FM_UIOMRD64_MIN).unwrap();
     assert_eq!(dw0.tlp_type, FlitTlpType::UioMemRead);
-    assert_eq!(dw0.ohc,    0);
+    assert_eq!(dw0.ohc, 0);
     assert_eq!(dw0.length, 2);
 }
 
@@ -576,8 +532,8 @@ fn flit_t4_stream_fragment_0_offsets() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(entries.len(), 4);
-    assert_eq!(entries[0], (0,  FlitTlpType::Nop,       4));
-    assert_eq!(entries[1], (4,  FlitTlpType::MemRead32, 12));
+    assert_eq!(entries[0], (0, FlitTlpType::Nop, 4));
+    assert_eq!(entries[1], (4, FlitTlpType::MemRead32, 12));
     assert_eq!(entries[2], (16, FlitTlpType::MemWrite32, 16));
     assert_eq!(entries[3], (32, FlitTlpType::UioMemRead, 16));
 }
@@ -624,10 +580,13 @@ fn flit_t5_end_to_end_cas32() {
     // CAS32 flit: 3 DW header + 2 DW payload (compare + swap)
     let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.flit_type(), Some(FlitTlpType::CompareSwap32));
-    assert_eq!(pkt.data(), [
-        0x11, 0x11, 0x11, 0x11, // compare
-        0x22, 0x22, 0x22, 0x22, // swap
-    ]);
+    assert_eq!(
+        pkt.data(),
+        [
+            0x11, 0x11, 0x11, 0x11, // compare
+            0x22, 0x22, 0x22, 0x22, // swap
+        ]
+    );
 }
 
 #[test]
@@ -643,10 +602,10 @@ fn flit_t5_end_to_end_uiomwr64() {
     // UIOMWr64 flit: 4 DW header + 2 DW payload
     let pkt = TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.flit_type(), Some(FlitTlpType::UioMemWrite));
-    assert_eq!(pkt.data(), [
-        0x11, 0x22, 0x33, 0x44,
-        0x55, 0x66, 0x77, 0x88,
-    ]);
+    assert_eq!(
+        pkt.data(),
+        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,]
+    );
 }
 
 #[test]
@@ -680,7 +639,10 @@ fn flit_t5_fetchadd32_operand_value_in_payload() {
     // Payload = 3 DW header consumed, remaining = [0x01, 0x00, 0x00, 0x00]
     assert_eq!(pkt.data().len(), 4, "FetchAdd32 has 1 DW operand");
     let operand = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
-    assert_eq!(operand, 0x01000000, "FM_FETCHADD32 addend should be 0x01000000");
+    assert_eq!(
+        operand, 0x01000000,
+        "FM_FETCHADD32 addend should be 0x01000000"
+    );
 }
 
 #[test]
@@ -689,10 +651,13 @@ fn flit_t5_cas32_operand_values_in_payload() {
     let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
     assert_eq!(pkt.flit_type(), Some(FlitTlpType::CompareSwap32));
     // Payload = 3 DW header consumed, remaining = 8 bytes (compare + swap)
-    assert_eq!(pkt.data().len(), 8, "CAS32 has 2 DW payload (compare + swap)");
+    assert_eq!(
+        pkt.data().len(),
+        8,
+        "CAS32 has 2 DW payload (compare + swap)"
+    );
     let compare = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
-    let swap    = u32::from_be_bytes([pkt.data()[4], pkt.data()[5], pkt.data()[6], pkt.data()[7]]);
+    let swap = u32::from_be_bytes([pkt.data()[4], pkt.data()[5], pkt.data()[6], pkt.data()[7]]);
     assert_eq!(compare, 0x11111111, "FM_CAS32 compare operand");
-    assert_eq!(swap,    0x22222222, "FM_CAS32 swap operand");
+    assert_eq!(swap, 0x22222222, "FM_CAS32 swap operand");
 }
-

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -10,7 +10,7 @@
 //! | 0 | ✅ passes today | N/A — permanent stub regression guard |
 //! | 1 | ✅ passes today | `FlitDW0::from_dw0()` ← **implemented** |
 //! | 2 | ✅ passes today | `FlitTlpType::base_header_dw()` ← **implemented** |
-//! | 3 | `#[ignore]` | OHC parser + `TlpError::MissingMandatoryOhc` |
+//! | 3 | ✅ passes today | `FlitOhcA` + `validate_mandatory_ohc()` ← **implemented** |
 //! | 4 | `#[ignore]` | `FlitStreamWalker` / stream iterator |
 //! | 5 | `#[ignore]` | `TlpPacket::new_flit()` fully wired |
 //!

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -465,63 +465,76 @@ fn flit_t2_local_prefix_base_header_is_1dw() {
 
 // ============================================================================
 // Tier 3 — OHC field parsing and mandatory OHC validation
-//
-// #[ignore] — pending: OHC parser + TlpError::MissingMandatoryOhc variant
 // ============================================================================
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_mrd32_a1_pasid_extraction() {
-    todo!(
-        "FM_MRD32_A1_PASID: OHC-A1 word = [0x01,0x23,0x45,0x0F]
-         → PASID = 0x12345, fdwbe = 0xF, ldwbe = 0x0"
-    );
+    // FM_MRD32_A1_PASID: 3 DW base header → OHC-A word starts at byte 12
+    // OHC-A1 word = [0x01, 0x23, 0x45, 0x0F]
+    let dw0 = FlitDW0::from_dw0(&FM_MRD32_A1_PASID).unwrap();
+    let ohc_offset = dw0.tlp_type.base_header_dw() as usize * 4; // = 12
+    let ohc = FlitOhcA::from_bytes(&FM_MRD32_A1_PASID[ohc_offset..]).unwrap();
+    assert_eq!(ohc.pasid, 0x12345);
+    assert_eq!(ohc.fdwbe, 0xF);
+    assert_eq!(ohc.ldwbe, 0x0);
 }
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_mwr32_partial_a1_be_extraction() {
-    todo!(
-        "FM_MWR32_PARTIAL_A1: OHC-A1 word = [0x00,0x00,0x00,0x03]
-         → fdwbe = 0x3 (partial-byte write), ldwbe = 0x0"
-    );
+    // FM_MWR32_PARTIAL_A1: OHC-A1 word = [0x00, 0x00, 0x00, 0x03]
+    let dw0 = FlitDW0::from_dw0(&FM_MWR32_PARTIAL_A1).unwrap();
+    let ohc_offset = dw0.tlp_type.base_header_dw() as usize * 4; // = 12
+    let ohc = FlitOhcA::from_bytes(&FM_MWR32_PARTIAL_A1[ohc_offset..]).unwrap();
+    assert_eq!(ohc.pasid, 0);
+    assert_eq!(ohc.fdwbe, 0x3); // partial-byte write
+    assert_eq!(ohc.ldwbe, 0x0);
 }
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_iowr_a2_mandatory_ohc_present() {
-    todo!(
-        "FM_IOWR_A2: OHC-A2 present (byte1 bit0=1)
-         → parser succeeds and extracts fdwbe=0xF"
-    );
+    // FM_IOWR_A2: OHC-A2 present (byte1 bit0=1) → validation succeeds
+    let dw0 = FlitDW0::from_dw0(&FM_IOWR_A2).unwrap();
+    assert!(dw0.validate_mandatory_ohc().is_ok());
+    // Also verify OHC-A2 word content
+    let ohc_offset = dw0.tlp_type.base_header_dw() as usize * 4; // = 12
+    let ohc = FlitOhcA::from_bytes(&FM_IOWR_A2[ohc_offset..]).unwrap();
+    assert_eq!(ohc.fdwbe, 0xF);
+    assert_eq!(ohc.ldwbe, 0x0);
 }
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_iowr_missing_mandatory_ohc_a2() {
+    // FM_IOWR_A2 with byte1 cleared → missing mandatory OHC-A2 → error
     let mut bad = FM_IOWR_A2.to_vec();
-    bad[1] = 0x00; // clear OHC flags — mandatory OHC-A2 missing
-    todo!(
-        "parse_flit_tlp(&bad) → Err(TlpError::MissingMandatoryOhc)"
+    bad[1] = 0x00; // clear OHC flags
+    let dw0 = FlitDW0::from_dw0(&bad).unwrap();
+    assert_eq!(
+        dw0.validate_mandatory_ohc(),
+        Err(TlpError::MissingMandatoryOhc)
     );
 }
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_cfgwr0_a3_mandatory_ohc_present() {
-    todo!(
-        "FM_CFGWR0_A3: OHC-A3 present
-         → parser succeeds and extracts fdwbe=0xF"
-    );
+    // FM_CFGWR0_A3: OHC-A3 present (byte1 bit0=1) → validation succeeds
+    let dw0 = FlitDW0::from_dw0(&FM_CFGWR0_A3).unwrap();
+    assert!(dw0.validate_mandatory_ohc().is_ok());
+    // Also verify OHC-A3 word content
+    let ohc_offset = dw0.tlp_type.base_header_dw() as usize * 4; // = 12
+    let ohc = FlitOhcA::from_bytes(&FM_CFGWR0_A3[ohc_offset..]).unwrap();
+    assert_eq!(ohc.fdwbe, 0xF);
+    assert_eq!(ohc.ldwbe, 0x0);
 }
 
 #[test]
-#[ignore = "pending: OHC parser not yet implemented (Tier 3)"]
 fn flit_t3_cfgwr_missing_mandatory_ohc_a3() {
+    // FM_CFGWR0_A3 with byte1 cleared → missing mandatory OHC-A3 → error
     let mut bad = FM_CFGWR0_A3.to_vec();
-    bad[1] = 0x00; // clear OHC flags — mandatory OHC-A3 missing
-    todo!(
-        "parse_flit_tlp(&bad) → Err(TlpError::MissingMandatoryOhc)"
+    bad[1] = 0x00; // clear OHC flags
+    let dw0 = FlitDW0::from_dw0(&bad).unwrap();
+    assert_eq!(
+        dw0.validate_mandatory_ohc(),
+        Err(TlpError::MissingMandatoryOhc)
     );
 }
 

--- a/tests/flit_mode_tests.rs
+++ b/tests/flit_mode_tests.rs
@@ -183,7 +183,7 @@ pub const FM_LOCAL_PREFIX_ONLY: [u8; 4] = [
 fn flit_packet_new_succeeds_for_valid_flit() {
     // TlpMode::Flit pipeline: MRd32 (3 DW base header, no payload despite Length=1)
     let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemRead32));
     assert!(pkt.data().is_empty()); // read request — no payload in the request packet
 }
 
@@ -607,7 +607,7 @@ fn flit_t4_stream_truncated_payload_error() {
 fn flit_t5_end_to_end_mrd32_min() {
     // MRd32 flit: 3 DW base header, no payload despite Length=1
     let pkt = TlpPacket::new(FM_MRD32_MIN.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemRead32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemRead32));
     assert!(pkt.data().is_empty());
 }
 
@@ -615,7 +615,7 @@ fn flit_t5_end_to_end_mrd32_min() {
 fn flit_t5_end_to_end_mwr32_min() {
     // MWr32 flit: 3 DW header + 1 DW payload
     let pkt = TlpPacket::new(FM_MWR32_MIN.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::MemWrite32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::MemWrite32));
     assert_eq!(pkt.data(), [0xDE, 0xAD, 0xBE, 0xEF]);
 }
 
@@ -623,7 +623,7 @@ fn flit_t5_end_to_end_mwr32_min() {
 fn flit_t5_end_to_end_cas32() {
     // CAS32 flit: 3 DW header + 2 DW payload (compare + swap)
     let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::CompareSwap32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::CompareSwap32));
     assert_eq!(pkt.data(), [
         0x11, 0x11, 0x11, 0x11, // compare
         0x22, 0x22, 0x22, 0x22, // swap
@@ -634,7 +634,7 @@ fn flit_t5_end_to_end_cas32() {
 fn flit_t5_end_to_end_dmwr32() {
     // DMWr32 flit: 3 DW header + 1 DW payload
     let pkt = TlpPacket::new(FM_DMWR32.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::DeferrableMemWrite32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::DeferrableMemWrite32));
     assert_eq!(pkt.data(), [0xC0, 0xFF, 0xEE, 0x00]);
 }
 
@@ -642,7 +642,7 @@ fn flit_t5_end_to_end_dmwr32() {
 fn flit_t5_end_to_end_uiomwr64() {
     // UIOMWr64 flit: 4 DW header + 2 DW payload
     let pkt = TlpPacket::new(FM_UIOMWR64_MIN.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::UioMemWrite));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::UioMemWrite));
     assert_eq!(pkt.data(), [
         0x11, 0x22, 0x33, 0x44,
         0x55, 0x66, 0x77, 0x88,
@@ -653,7 +653,7 @@ fn flit_t5_end_to_end_uiomwr64() {
 fn flit_t5_nop_has_no_data() {
     // NOP flit: 1 DW header, no payload
     let pkt = TlpPacket::new(FM_NOP.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::Nop));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::Nop));
     assert!(pkt.data().is_empty());
 }
 
@@ -661,7 +661,7 @@ fn flit_t5_nop_has_no_data() {
 fn flit_t5_nonflit_packet_get_flit_type_returns_none() {
     // Non-flit packets must return None from get_flit_type()
     let pkt = TlpPacket::new(vec![0x00, 0x00, 0x00, 0x01], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_flit_type(), None);
+    assert_eq!(pkt.flit_type(), None);
 }
 
 // ============================================================================
@@ -676,7 +676,7 @@ fn flit_t5_fetchadd32_operand_value_in_payload() {
     // FM_FETCHADD32 operand = 0x01000000 (comment says "Operand = 0x01000000")
     // Verify: parse the flit packet and check that data() contains the operand bytes
     let pkt = TlpPacket::new(FM_FETCHADD32.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::FetchAdd32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::FetchAdd32));
     // Payload = 3 DW header consumed, remaining = [0x01, 0x00, 0x00, 0x00]
     assert_eq!(pkt.data().len(), 4, "FetchAdd32 has 1 DW operand");
     let operand = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
@@ -687,7 +687,7 @@ fn flit_t5_fetchadd32_operand_value_in_payload() {
 fn flit_t5_cas32_operand_values_in_payload() {
     // FM_CAS32: Compare=0x11111111, Swap=0x22222222 (as documented in the constant)
     let pkt = TlpPacket::new(FM_CAS32.to_vec(), TlpMode::Flit).unwrap();
-    assert_eq!(pkt.get_flit_type(), Some(FlitTlpType::CompareSwap32));
+    assert_eq!(pkt.flit_type(), Some(FlitTlpType::CompareSwap32));
     // Payload = 3 DW header consumed, remaining = 8 bytes (compare + swap)
     assert_eq!(pkt.data().len(), 8, "CAS32 has 2 DW payload (compare + swap)");
     let compare = u32::from_be_bytes([pkt.data()[0], pkt.data()[1], pkt.data()[2], pkt.data()[3]]);
@@ -695,3 +695,4 @@ fn flit_t5_cas32_operand_values_in_payload() {
     assert_eq!(compare, 0x11111111, "FM_CAS32 compare operand");
     assert_eq!(swap,    0x22222222, "FM_CAS32 swap operand");
 }
+

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -29,7 +29,9 @@ fn mk_pkt(dw0_fmt: u8, dw0_type: u8, data: &[u8]) -> TlpPacket {
 /// parsing only (split at byte 4) and does not enforce semantic payload rules.
 #[test]
 fn test_tlp_packet() {
-    let d = vec![0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
+    let d = vec![
+        0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10,
+    ];
     let tlp = TlpPacket::new(d, TlpMode::NonFlit).unwrap();
 
     assert_eq!(tlp.tlp_type().unwrap(), TlpType::ConfType0ReadReq);
@@ -75,11 +77,21 @@ fn memreq_tag_field_3dw_and_4dw() {
     assert_eq!(0x10, mr3dw3.tag());
     assert_eq!(0x81, mr3dw4.tag());
 
-    let mr4dw1 = MemRequest4DW([0x00, 0x00, 0x01, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
-    let mr4dw2 = MemRequest4DW([0x00, 0x00, 0x10, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
-    let mr4dw3 = MemRequest4DW([0x00, 0x00, 0x81, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
-    let mr4dw4 = MemRequest4DW([0x00, 0x00, 0xFF, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
-    let mr4dw5 = MemRequest4DW([0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00]);
+    let mr4dw1 = MemRequest4DW([
+        0x00, 0x00, 0x01, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
+    let mr4dw2 = MemRequest4DW([
+        0x00, 0x00, 0x10, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
+    let mr4dw3 = MemRequest4DW([
+        0x00, 0x00, 0x81, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
+    let mr4dw4 = MemRequest4DW([
+        0x00, 0x00, 0xFF, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
+    let mr4dw5 = MemRequest4DW([
+        0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ]);
 
     assert_eq!(0x01, mr4dw1.tag());
     assert_eq!(0x10, mr4dw2.tag());
@@ -100,7 +112,9 @@ fn memreq_3dw_address_field() {
 #[test]
 fn memreq_4dw_address_field() {
     // DW1+DW2+DW3 bytes: address64 = 0x17FC0000000
-    let memreq_4dw = [0x00, 0x00, 0x20, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00];
+    let memreq_4dw = [
+        0x00, 0x00, 0x20, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00,
+    ];
     let mr = MemRequest4DW(memreq_4dw);
 
     assert_eq!(0x17fc0000000, mr.address());
@@ -110,7 +124,9 @@ fn memreq_4dw_address_field() {
 fn tlp_packet_header_constructs_from_bytes() {
     // MemRead32 bytes: DW0=0x00 (Fmt=000, Type=00000), TC/flags, Length=1
     // Followed by DW1+DW2 (req_id, tag, BE, address)
-    let memrd32_header = [0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
+    let memrd32_header = [
+        0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C,
+    ];
 
     let mr = TlpPacketHeader::new(memrd32_header.to_vec(), TlpMode::NonFlit).unwrap();
     assert_eq!(mr.tlp_type().unwrap(), TlpType::MemReadReq);
@@ -137,10 +153,7 @@ fn atomic_fetchadd_3dw_32_parses_operands() {
 
     // DW1+DW2 header bytes as MemRequest3DW expects:
     // req_id=0x1234, tag=0x56, address32=0x89ABCDEF
-    let hdr = [
-        0x12, 0x34, 0x56, 0x00,
-        0x89, 0xAB, 0xCD, 0xEF,
-    ];
+    let hdr = [0x12, 0x34, 0x56, 0x00, 0x89, 0xAB, 0xCD, 0xEF];
 
     // 32-bit operand (BE) = 0xDEADBEEF
     let operand = [0xDE, 0xAD, 0xBE, 0xEF];
@@ -170,13 +183,11 @@ fn atomic_swap_4dw_64_parses_operands() {
     // MemRequest4DW-like header in data:
     // req_id=0xBEEF, tag=0xA5, address64=0x1122334455667788
     let hdr = [
-        0xBE, 0xEF, 0xA5, 0x00,
-        0x11, 0x22, 0x33, 0x44,
-        0x55, 0x66, 0x77, 0x88,
+        0xBE, 0xEF, 0xA5, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
     ];
 
     // 64-bit operand = 0x0102030405060708 (BE)
-    let operand = [0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08];
+    let operand = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 
     let mut data = Vec::new();
     data.extend_from_slice(&hdr);
@@ -201,12 +212,11 @@ fn atomic_cas_3dw_32_parses_operands() {
     const TY_ATOM_CAS: u8 = 0b01110;
 
     let hdr = [
-        0xCA, 0xFE, 0x11, 0x00,
-        0x00, 0x00, 0x10, 0x00,  // address32 = 0x00001000
+        0xCA, 0xFE, 0x11, 0x00, 0x00, 0x00, 0x10, 0x00, // address32 = 0x00001000
     ];
 
     // compare=0x11112222, swap=0x33334444
-    let payload = [0x11,0x11,0x22,0x22, 0x33,0x33,0x44,0x44];
+    let payload = [0x11, 0x11, 0x22, 0x22, 0x33, 0x33, 0x44, 0x44];
 
     let mut data = Vec::new();
     data.extend_from_slice(&hdr);
@@ -230,13 +240,10 @@ fn atomic_fetchadd_rejects_invalid_operand_length() {
     const FMT_3DW_WITH_DATA: u8 = 0b010;
     const TY_ATOM_FETCH: u8 = 0b01100;
 
-    let hdr = [
-        0x12, 0x34, 0x56, 0x00,
-        0x89, 0xAB, 0xCD, 0xEF,
-    ];
+    let hdr = [0x12, 0x34, 0x56, 0x00, 0x89, 0xAB, 0xCD, 0xEF];
 
     // 6 bytes is invalid (not 4 or 8)
-    let bad_operand = [1,2,3,4,5,6];
+    let bad_operand = [1, 2, 3, 4, 5, 6];
 
     let mut data = Vec::new();
     data.extend_from_slice(&hdr);
@@ -271,12 +278,26 @@ fn dmwr64_decode_via_tlppacket() {
 #[test]
 fn dmwr_rejects_nodata_formats() {
     // NoData 3DW: fmt=000, type=11011 → byte0 = 0x1B
-    let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt1.tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+    let pkt1 = TlpPacket::new(
+        vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    )
+    .unwrap();
+    assert_eq!(
+        pkt1.tlp_type().unwrap_err(),
+        TlpError::UnsupportedCombination
+    );
 
     // NoData 4DW: fmt=001, type=11011 → byte0 = 0x3B
-    let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt2.tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+    let pkt2 = TlpPacket::new(
+        vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    )
+    .unwrap();
+    assert_eq!(
+        pkt2.tlp_type().unwrap_err(),
+        TlpError::UnsupportedCombination
+    );
 }
 
 #[test]
@@ -293,28 +314,43 @@ fn dmwr_is_non_posted() {
 #[test]
 fn msg_req_decode_route_to_rc_3dw_no_data() {
     // Fmt=000 (3DW no data), Type=10000 (route to RC) → byte0 = 0x10
-    let pkt = TlpPacket::new(vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    let pkt = TlpPacket::new(
+        vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    )
+    .unwrap();
     assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReq);
 }
 
 #[test]
 fn msg_req_data_decode_route_to_rc_3dw_with_data() {
     // Fmt=010 (3DW with data), Type=10000 (route to RC) → byte0 = 0x50
-    let pkt = TlpPacket::new(vec![0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    let pkt = TlpPacket::new(
+        vec![0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        TlpMode::NonFlit,
+    )
+    .unwrap();
     assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReqData);
 }
 
 #[test]
+#[allow(clippy::identity_op)] // 0b000 << 5 == 0 is intentional: documents the Fmt=000 field
 fn msg_req_all_six_routing_subtypes_decode() {
     // Verify all 6 message routing sub-types decode to MsgReq (no-data Fmt=000)
     // Type[4:0]: 10000=routeRC, 10001=routeAddr, 10010=routeID,
     //            10011=broadcast, 10100=local, 10101=gathered
     for routing_bits in 0b10000u8..=0b10101u8 {
         let byte0 = (0b000 << 5) | (routing_bits & 0x1f); // Fmt=000
-        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        let pkt = TlpPacket::new(
+            vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            TlpMode::NonFlit,
+        )
+        .unwrap();
         assert_eq!(
-            pkt.tlp_type().unwrap(), TlpType::MsgReq,
-            "Routing sub-type {:#07b} should decode to MsgReq", routing_bits
+            pkt.tlp_type().unwrap(),
+            TlpType::MsgReq,
+            "Routing sub-type {:#07b} should decode to MsgReq",
+            routing_bits
         );
     }
 }
@@ -324,10 +360,16 @@ fn msg_req_data_all_six_routing_subtypes_decode() {
     // Verify all 6 routing sub-types with Fmt=010 decode to MsgReqData
     for routing_bits in 0b10000u8..=0b10101u8 {
         let byte0 = (0b010 << 5) | (routing_bits & 0x1f); // Fmt=010
-        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        let pkt = TlpPacket::new(
+            vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            TlpMode::NonFlit,
+        )
+        .unwrap();
         assert_eq!(
-            pkt.tlp_type().unwrap(), TlpType::MsgReqData,
-            "Routing sub-type {:#07b} with WithData3DW should decode to MsgReqData", routing_bits
+            pkt.tlp_type().unwrap(),
+            TlpType::MsgReqData,
+            "Routing sub-type {:#07b} with WithData3DW should decode to MsgReqData",
+            routing_bits
         );
     }
 }
@@ -347,8 +389,8 @@ fn msg_req_end_to_end_path_with_new_msg_req() {
     assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReq);
 
     let msg = new_msg_req(pkt.data().to_vec());
-    assert_eq!(msg.req_id(),   0xBEEF);
-    assert_eq!(msg.tag(),      0xA5);
+    assert_eq!(msg.req_id(), 0xBEEF);
+    assert_eq!(msg.tag(), 0xA5);
     assert_eq!(msg.msg_code(), 0x7E);
 }
 
@@ -378,15 +420,23 @@ fn tlp_prefix_local_and_end_to_end_distinguished_by_bit4() {
     for type_bits in [0b00000u8, 0b00001, 0b00010, 0b00100, 0b01010] {
         let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.tlp_type().unwrap(), TlpType::LocalTlpPrefix,
-            "byte0={:#04x} (Type[4]=0) should be LocalTlpPrefix", byte0);
+        assert_eq!(
+            pkt.tlp_type().unwrap(),
+            TlpType::LocalTlpPrefix,
+            "byte0={:#04x} (Type[4]=0) should be LocalTlpPrefix",
+            byte0
+        );
     }
     // All Type values with bit 4=1 → EndToEndTlpPrefix
     for type_bits in [0b10000u8, 0b10001, 0b10010, 0b11011] {
         let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.tlp_type().unwrap(), TlpType::EndToEndTlpPrefix,
-            "byte0={:#04x} (Type[4]=1) should be EndToEndTlpPrefix", byte0);
+        assert_eq!(
+            pkt.tlp_type().unwrap(),
+            TlpType::EndToEndTlpPrefix,
+            "byte0={:#04x} (Type[4]=1) should be EndToEndTlpPrefix",
+            byte0
+        );
     }
 }
 
@@ -396,4 +446,3 @@ fn prefix_types_are_not_non_posted() {
     assert!(!TlpType::LocalTlpPrefix.is_non_posted());
     assert!(!TlpType::EndToEndTlpPrefix.is_non_posted());
 }
-

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -274,3 +274,114 @@ fn dmwr_is_non_posted() {
     // Normal MemWrite is posted (not non-posted)
     assert!(!TlpType::MemWriteReq.is_non_posted());
 }
+
+// ============================================================================
+// Message TLP decode (was previously broken — Type[4:3]=10 = message)
+// ============================================================================
+
+#[test]
+fn msg_req_decode_route_to_rc_3dw_no_data() {
+    // Fmt=000 (3DW no data), Type=10000 (route to RC) → byte0 = 0x10
+    let pkt = TlpPacket::new(vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReq);
+}
+
+#[test]
+fn msg_req_data_decode_route_to_rc_3dw_with_data() {
+    // Fmt=010 (3DW with data), Type=10000 (route to RC) → byte0 = 0x50
+    let pkt = TlpPacket::new(vec![0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReqData);
+}
+
+#[test]
+fn msg_req_all_six_routing_subtypes_decode() {
+    // Verify all 6 message routing sub-types decode to MsgReq (no-data Fmt=000)
+    // Type[4:0]: 10000=routeRC, 10001=routeAddr, 10010=routeID,
+    //            10011=broadcast, 10100=local, 10101=gathered
+    for routing_bits in 0b10000u8..=0b10101u8 {
+        let byte0 = (0b000 << 5) | (routing_bits & 0x1f); // Fmt=000
+        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(
+            pkt.get_tlp_type().unwrap(), TlpType::MsgReq,
+            "Routing sub-type {:#07b} should decode to MsgReq", routing_bits
+        );
+    }
+}
+
+#[test]
+fn msg_req_data_all_six_routing_subtypes_decode() {
+    // Verify all 6 routing sub-types with Fmt=010 decode to MsgReqData
+    for routing_bits in 0b10000u8..=0b10101u8 {
+        let byte0 = (0b010 << 5) | (routing_bits & 0x1f); // Fmt=010
+        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(
+            pkt.get_tlp_type().unwrap(), TlpType::MsgReqData,
+            "Routing sub-type {:#07b} with WithData3DW should decode to MsgReqData", routing_bits
+        );
+    }
+}
+
+#[test]
+fn msg_req_end_to_end_path_with_new_msg_req() {
+    // Full end-to-end: packet decode → get_tlp_type() → new_msg_req() → field access
+    // Fmt=000, Type=10000 (route to RC) → byte0 = 0x10
+    // DW1: req_id=0xBEEF, tag=0xA5, msg_code=0x7E
+    // DW2: route word (zero)
+    let pkt_bytes = vec![
+        0x10, 0x00, 0x00, 0x00, // DW0: MsgReq route-to-RC
+        0xBE, 0xEF, 0xA5, 0x7E, // DW1: req_id=0xBEEF, tag=0xA5, msg_code=0x7E
+        0x00, 0x00, 0x00, 0x00, // DW2: route word
+    ];
+    let pkt = TlpPacket::new(pkt_bytes, TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReq);
+
+    let msg = new_msg_req(pkt.data().to_vec());
+    assert_eq!(msg.req_id(),   0xBEEF);
+    assert_eq!(msg.tag(),      0xA5);
+    assert_eq!(msg.msg_code(), 0x7E);
+}
+
+// ============================================================================
+// TLP Prefix decode (was previously broken — Fmt=0b100)
+// ============================================================================
+
+#[test]
+fn local_tlp_prefix_decode_type4_zero() {
+    // Fmt=100 (TlpPrefix), Type[4]=0 → LocalTlpPrefix
+    // byte0 = (0b100 << 5) | 0b00000 = 0x80
+    let pkt = TlpPacket::new(vec![0x80, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::LocalTlpPrefix);
+}
+
+#[test]
+fn end_to_end_tlp_prefix_decode_type4_one() {
+    // Fmt=100 (TlpPrefix), Type[4]=1 → EndToEndTlpPrefix
+    // byte0 = (0b100 << 5) | 0b10000 = 0x90
+    let pkt = TlpPacket::new(vec![0x90, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::EndToEndTlpPrefix);
+}
+
+#[test]
+fn tlp_prefix_local_and_end_to_end_distinguished_by_bit4() {
+    // All Type values with bit 4=0 → LocalTlpPrefix
+    for type_bits in [0b00000u8, 0b00001, 0b00010, 0b00100, 0b01010] {
+        let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
+        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::LocalTlpPrefix,
+            "byte0={:#04x} (Type[4]=0) should be LocalTlpPrefix", byte0);
+    }
+    // All Type values with bit 4=1 → EndToEndTlpPrefix
+    for type_bits in [0b10000u8, 0b10001, 0b10010, 0b11011] {
+        let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
+        let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
+        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::EndToEndTlpPrefix,
+            "byte0={:#04x} (Type[4]=1) should be EndToEndTlpPrefix", byte0);
+    }
+}
+
+#[test]
+fn prefix_types_are_not_non_posted() {
+    // Prefix objects are not transactions — is_non_posted() is false
+    assert!(!TlpType::LocalTlpPrefix.is_non_posted());
+    assert!(!TlpType::EndToEndTlpPrefix.is_non_posted());
+}

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -27,7 +27,7 @@ fn test_tlp_packet() {
     let tlp = TlpPacket::new(d, TlpMode::NonFlit).unwrap();
 
     assert_eq!(tlp.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
-    assert_eq!(tlp.get_data(), vec![0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
+    assert_eq!(tlp.data(), [0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
 }
 
 #[test]

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -21,12 +21,19 @@ fn mk_pkt(dw0_fmt: u8, dw0_type: u8, data: &[u8]) -> TlpPacket {
     TlpPacket::new(v, TlpMode::NonFlit).unwrap()
 }
 
+/// Structural split test: verifies that TlpPacket correctly identifies DW0 type
+/// and separates the remaining bytes into data().
+///
+/// Note: per PCIe §2.2.4, Configuration Read Requests carry **no data payload** —
+/// this packet would be invalid on a real PCIe link. The library performs structural
+/// parsing only (split at byte 4) and does not enforce semantic payload rules.
 #[test]
 fn test_tlp_packet() {
     let d = vec![0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
     let tlp = TlpPacket::new(d, TlpMode::NonFlit).unwrap();
 
     assert_eq!(tlp.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
+    // DW0 consumed as header; bytes[4..11] go into data() for downstream parsing
     assert_eq!(tlp.data(), [0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
 }
 

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -64,7 +64,7 @@ fn test_configreq_trait() {
 }
 
 #[test]
-fn is_memreq_tag_works() {
+fn memreq_tag_field_3dw_and_4dw() {
     let mr3dw1 = MemRequest3DW([0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C]);
     let mr3dw2 = MemRequest3DW([0x00, 0x00, 0x01, 0x0F, 0xF6, 0x20, 0x00, 0x0C]);
     let mr3dw3 = MemRequest3DW([0x00, 0x00, 0x10, 0x0F, 0xF6, 0x20, 0x00, 0x0C]);
@@ -89,7 +89,8 @@ fn is_memreq_tag_works() {
 }
 
 #[test]
-fn is_memreq_3dw_address_works() {
+fn memreq_3dw_address_field() {
+    // DW1+DW2 bytes: req_id=0x0000, tag=0x20, BE=0x0F, address32=0xF620000C
     let memreq_3dw = [0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
     let mr = MemRequest3DW(memreq_3dw);
 
@@ -97,7 +98,8 @@ fn is_memreq_3dw_address_works() {
 }
 
 #[test]
-fn is_memreq_4dw_address_works() {
+fn memreq_4dw_address_field() {
+    // DW1+DW2+DW3 bytes: address64 = 0x17FC0000000
     let memreq_4dw = [0x00, 0x00, 0x20, 0x0F, 0x00, 0x00, 0x01, 0x7f, 0xc0, 0x00, 0x00, 0x00];
     let mr = MemRequest4DW(memreq_4dw);
 
@@ -105,7 +107,9 @@ fn is_memreq_4dw_address_works() {
 }
 
 #[test]
-fn is_tlppacket_creates() {
+fn tlp_packet_header_constructs_from_bytes() {
+    // MemRead32 bytes: DW0=0x00 (Fmt=000, Type=00000), TC/flags, Length=1
+    // Followed by DW1+DW2 (req_id, tag, BE, address)
     let memrd32_header = [0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
 
     let mr = TlpPacketHeader::new(memrd32_header.to_vec(), TlpMode::NonFlit).unwrap();

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -1,3 +1,12 @@
+//! Non-Flit Mode Integration Tests (PCIe 1.0 – 5.0)
+//!
+//! Scope: functional behavior of the library when using `TlpMode::NonFlit`.
+//! Every `TlpPacket::new` and `TlpPacketHeader::new` call in this file must
+//! pass `TlpMode::NonFlit` explicitly.
+//!
+//! For flit mode (PCIe 6.x) tests see `tests/flit_mode_tests.rs`.
+//! For API surface / stability tests see `tests/api_tests.rs`.
+
 use rtlp_lib::*;
 
 // ── helpers ───────────────────────────────────────────────────────────────

--- a/tests/non_flit_tests.rs
+++ b/tests/non_flit_tests.rs
@@ -32,7 +32,7 @@ fn test_tlp_packet() {
     let d = vec![0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
     let tlp = TlpPacket::new(d, TlpMode::NonFlit).unwrap();
 
-    assert_eq!(tlp.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
+    assert_eq!(tlp.tlp_type().unwrap(), TlpType::ConfType0ReadReq);
     // DW0 consumed as header; bytes[4..11] go into data() for downstream parsing
     assert_eq!(tlp.data(), [0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
 }
@@ -113,7 +113,7 @@ fn tlp_packet_header_constructs_from_bytes() {
     let memrd32_header = [0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
 
     let mr = TlpPacketHeader::new(memrd32_header.to_vec(), TlpMode::NonFlit).unwrap();
-    assert_eq!(mr.get_tlp_type().unwrap(), TlpType::MemReadReq);
+    assert_eq!(mr.tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_tlp_packet_invalid_type() {
     // Test that TlpPacket::get_tlp_type properly returns error
     let invalid_data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
     let packet = TlpPacket::new(invalid_data, TlpMode::NonFlit).unwrap();
-    let result = packet.get_tlp_type();
+    let result = packet.tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
 }
@@ -150,7 +150,7 @@ fn atomic_fetchadd_3dw_32_parses_operands() {
     data.extend_from_slice(&operand);
 
     let pkt = mk_pkt(FMT_3DW_WITH_DATA, TY_ATOM_FETCH, &data);
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::FetchAddAtomicOpReq);
 
     let a = new_atomic_req(&pkt).unwrap();
     assert_eq!(a.op(), AtomicOp::FetchAdd);
@@ -183,7 +183,7 @@ fn atomic_swap_4dw_64_parses_operands() {
     data.extend_from_slice(&operand);
 
     let pkt = mk_pkt(FMT_4DW_WITH_DATA, TY_ATOM_SWAP, &data);
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::SwapAtomicOpReq);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::SwapAtomicOpReq);
 
     let a = new_atomic_req(&pkt).unwrap();
     assert_eq!(a.op(), AtomicOp::Swap);
@@ -213,7 +213,7 @@ fn atomic_cas_3dw_32_parses_operands() {
     data.extend_from_slice(&payload);
 
     let pkt = mk_pkt(FMT_3DW_WITH_DATA, TY_ATOM_CAS, &data);
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::CompareSwapAtomicOpReq);
 
     let a = new_atomic_req(&pkt).unwrap();
     assert_eq!(a.op(), AtomicOp::CompareSwap);
@@ -255,8 +255,8 @@ fn dmwr32_decode_via_tlppacket() {
     // DMWr32: fmt=010, type=11011 → byte0 = 0x5B
     let data = vec![0x5B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
     let pkt = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
-    assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+    assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 }
 
 #[test]
@@ -264,19 +264,19 @@ fn dmwr64_decode_via_tlppacket() {
     // DMWr64: fmt=011, type=11011 → byte0 = 0x7B
     let data = vec![0x7B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
     let pkt = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
-    assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
+    assert_eq!(pkt.tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 }
 
 #[test]
 fn dmwr_rejects_nodata_formats() {
     // NoData 3DW: fmt=000, type=11011 → byte0 = 0x1B
     let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt1.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+    assert_eq!(pkt1.tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 
     // NoData 4DW: fmt=001, type=11011 → byte0 = 0x3B
     let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt2.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
+    assert_eq!(pkt2.tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 }
 
 #[test]
@@ -294,14 +294,14 @@ fn dmwr_is_non_posted() {
 fn msg_req_decode_route_to_rc_3dw_no_data() {
     // Fmt=000 (3DW no data), Type=10000 (route to RC) → byte0 = 0x10
     let pkt = TlpPacket::new(vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReq);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReq);
 }
 
 #[test]
 fn msg_req_data_decode_route_to_rc_3dw_with_data() {
     // Fmt=010 (3DW with data), Type=10000 (route to RC) → byte0 = 0x50
     let pkt = TlpPacket::new(vec![0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReqData);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReqData);
 }
 
 #[test]
@@ -313,7 +313,7 @@ fn msg_req_all_six_routing_subtypes_decode() {
         let byte0 = (0b000 << 5) | (routing_bits & 0x1f); // Fmt=000
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
         assert_eq!(
-            pkt.get_tlp_type().unwrap(), TlpType::MsgReq,
+            pkt.tlp_type().unwrap(), TlpType::MsgReq,
             "Routing sub-type {:#07b} should decode to MsgReq", routing_bits
         );
     }
@@ -326,7 +326,7 @@ fn msg_req_data_all_six_routing_subtypes_decode() {
         let byte0 = (0b010 << 5) | (routing_bits & 0x1f); // Fmt=010
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
         assert_eq!(
-            pkt.get_tlp_type().unwrap(), TlpType::MsgReqData,
+            pkt.tlp_type().unwrap(), TlpType::MsgReqData,
             "Routing sub-type {:#07b} with WithData3DW should decode to MsgReqData", routing_bits
         );
     }
@@ -344,7 +344,7 @@ fn msg_req_end_to_end_path_with_new_msg_req() {
         0x00, 0x00, 0x00, 0x00, // DW2: route word
     ];
     let pkt = TlpPacket::new(pkt_bytes, TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::MsgReq);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::MsgReq);
 
     let msg = new_msg_req(pkt.data().to_vec());
     assert_eq!(msg.req_id(),   0xBEEF);
@@ -361,7 +361,7 @@ fn local_tlp_prefix_decode_type4_zero() {
     // Fmt=100 (TlpPrefix), Type[4]=0 → LocalTlpPrefix
     // byte0 = (0b100 << 5) | 0b00000 = 0x80
     let pkt = TlpPacket::new(vec![0x80, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::LocalTlpPrefix);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::LocalTlpPrefix);
 }
 
 #[test]
@@ -369,7 +369,7 @@ fn end_to_end_tlp_prefix_decode_type4_one() {
     // Fmt=100 (TlpPrefix), Type[4]=1 → EndToEndTlpPrefix
     // byte0 = (0b100 << 5) | 0b10000 = 0x90
     let pkt = TlpPacket::new(vec![0x90, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-    assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::EndToEndTlpPrefix);
+    assert_eq!(pkt.tlp_type().unwrap(), TlpType::EndToEndTlpPrefix);
 }
 
 #[test]
@@ -378,14 +378,14 @@ fn tlp_prefix_local_and_end_to_end_distinguished_by_bit4() {
     for type_bits in [0b00000u8, 0b00001, 0b00010, 0b00100, 0b01010] {
         let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::LocalTlpPrefix,
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::LocalTlpPrefix,
             "byte0={:#04x} (Type[4]=0) should be LocalTlpPrefix", byte0);
     }
     // All Type values with bit 4=1 → EndToEndTlpPrefix
     for type_bits in [0b10000u8, 0b10001, 0b10010, 0b11011] {
         let byte0 = (0b100u8 << 5) | (type_bits & 0x1f);
         let pkt = TlpPacket::new(vec![byte0, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
-        assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::EndToEndTlpPrefix,
+        assert_eq!(pkt.tlp_type().unwrap(), TlpType::EndToEndTlpPrefix,
             "byte0={:#04x} (Type[4]=1) should be EndToEndTlpPrefix", byte0);
     }
 }
@@ -396,3 +396,4 @@ fn prefix_types_are_not_non_posted() {
     assert!(!TlpType::LocalTlpPrefix.is_non_posted());
     assert!(!TlpType::EndToEndTlpPrefix.is_non_posted());
 }
+

--- a/tests/tlp_tests.rs
+++ b/tests/tlp_tests.rs
@@ -9,13 +9,13 @@ fn mk_pkt(dw0_fmt: u8, dw0_type: u8, data: &[u8]) -> TlpPacket {
     v.push(0);
     v.push(0);
     v.extend_from_slice(data);
-    TlpPacket::new(v).unwrap()
+    TlpPacket::new(v, TlpMode::NonFlit).unwrap()
 }
 
 #[test]
 fn test_tlp_packet() {
     let d = vec![0x04, 0x00, 0x00, 0x01, 0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10];
-    let tlp = TlpPacket::new(d).unwrap();
+    let tlp = TlpPacket::new(d, TlpMode::NonFlit).unwrap();
 
     assert_eq!(tlp.get_tlp_type().unwrap(), TlpType::ConfType0ReadReq);
     assert_eq!(tlp.get_data(), vec![0x20, 0x01, 0xFF, 0x00, 0xC2, 0x81, 0xFF, 0x10]);
@@ -92,7 +92,7 @@ fn is_memreq_4dw_address_works() {
 fn is_tlppacket_creates() {
     let memrd32_header = [0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C];
 
-    let mr = TlpPacketHeader::new(memrd32_header.to_vec()).unwrap();
+    let mr = TlpPacketHeader::new(memrd32_header.to_vec(), TlpMode::NonFlit).unwrap();
     assert_eq!(mr.get_tlp_type().unwrap(), TlpType::MemReadReq);
 }
 
@@ -100,7 +100,7 @@ fn is_tlppacket_creates() {
 fn test_tlp_packet_invalid_type() {
     // Test that TlpPacket::get_tlp_type properly returns error
     let invalid_data = vec![0x0f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
-    let packet = TlpPacket::new(invalid_data).unwrap();
+    let packet = TlpPacket::new(invalid_data, TlpMode::NonFlit).unwrap();
     let result = packet.get_tlp_type();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), TlpError::InvalidType);
@@ -234,7 +234,7 @@ fn atomic_fetchadd_rejects_invalid_operand_length() {
 fn dmwr32_decode_via_tlppacket() {
     // DMWr32: fmt=010, type=11011 → byte0 = 0x5B
     let data = vec![0x5B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let pkt = TlpPacket::new(data).unwrap();
+    let pkt = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
     assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader3DW);
 }
@@ -243,7 +243,7 @@ fn dmwr32_decode_via_tlppacket() {
 fn dmwr64_decode_via_tlppacket() {
     // DMWr64: fmt=011, type=11011 → byte0 = 0x7B
     let data = vec![0x7B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    let pkt = TlpPacket::new(data).unwrap();
+    let pkt = TlpPacket::new(data, TlpMode::NonFlit).unwrap();
     assert_eq!(pkt.get_tlp_type().unwrap(), TlpType::DeferrableMemWriteReq);
     assert_eq!(pkt.get_tlp_format().unwrap(), TlpFmt::WithDataHeader4DW);
 }
@@ -251,11 +251,11 @@ fn dmwr64_decode_via_tlppacket() {
 #[test]
 fn dmwr_rejects_nodata_formats() {
     // NoData 3DW: fmt=000, type=11011 → byte0 = 0x1B
-    let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]).unwrap();
+    let pkt1 = TlpPacket::new(vec![0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
     assert_eq!(pkt1.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 
     // NoData 4DW: fmt=001, type=11011 → byte0 = 0x3B
-    let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]).unwrap();
+    let pkt2 = TlpPacket::new(vec![0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], TlpMode::NonFlit).unwrap();
     assert_eq!(pkt2.get_tlp_type().unwrap_err(), TlpError::UnsupportedCombination);
 }
 


### PR DESCRIPTION
This series of commits are adding flit mode support to the library.
This pull request introduces significant improvements to the `rtlp-lib` crate, focusing on PCIe 6.x flit mode support, test coverage expansion, and documentation clarity. The most important changes are the addition of new types and error variants for flit mode, a major increase in passing tests (with a structured test plan), and updates to usage examples and documentation to reflect these enhancements.

### Flit Mode Support and API Expansion
* Added new types for PCIe 6.x flit mode: `TlpMode`, `FlitTlpType`, and `FlitDW0`, as well as expanded the `TlpType` enum to clarify non-flit vs flit types. Introduced a new error variant `NotImplemented` for features not yet available.
* Updated usage examples to require explicit `TlpMode` (e.g., `TlpPacket::new(bytes, TlpMode::NonFlit)`) and included `TlpMode` in the import list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R38)

### Test Coverage and Structure
* Increased the test count from 102 to 156 passing tests (plus 14 ignored flit-mode placeholders), with detailed breakdowns for unit, integration, API contract, flit mode, and doc tests. Added a comprehensive test plan in `TESTS.md` and updated test commands in documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R165) [[2]](diffhunk://#diff-6129e4842294d2f7cbef7f74cda4f4457150fa9c642210659bffbdb51c092994R5-R232)

### Documentation and Versioning
* Clarified documentation for new types, error variants, and test structure. Added references to `TESTS.md` for full test details and flit mode tier descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R165) [[2]](diffhunk://#diff-6129e4842294d2f7cbef7f74cda4f4457150fa9c642210659bffbdb51c092994R5-R232)
* Bumped crate version from `0.3.1` to `0.4.1` to reflect the new features and expanded test coverage.