### PR TITLE
feat: add serde Serialize/Deserialize support (feature-gated)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
           components: clippy
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
+      - name: Run clippy (serde feature)
+        run: cargo clippy --all-targets --features serde -- -D warnings
 
   test:
     name: Tests
@@ -47,6 +49,8 @@ jobs:
           toolchain: "1.85"
       - name: Run tests
         run: cargo test --verbose
+      - name: Run tests (serde feature)
+        run: cargo test --verbose --features serde
 
   msrv:
     name: MSRV (1.85)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,13 @@ readme = "README.md"
 keywords = ["pcie", "tlp", "pci-express", "parser", "hardware"]
 categories = ["hardware-support", "parser-implementations"]
 
+[features]
+default = []
+serde = ["dep:serde"]
+
 [dependencies]
 bitfield = "0.14.0"
+serde = { version = "1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["hardware-support", "parser-implementations"]
 
 [features]
 default = []
+## Enables serde Serialize/Deserialize for all public value types
+## (TlpMode, TlpError, TlpFmt, TlpType, AtomicOp, FlitTlpType, FlitDW0, FlitOhcA).
+## TlpPacket and TlpPacketHeader are NOT included because TlpHeader uses
+## a bitfield macro that does not support serde derives.
 serde = ["dep:serde"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -219,6 +219,21 @@ cargo test --doc                  # doc examples only
 
 See [TESTS.md](TESTS.md) for the full test structure and flit mode tier descriptions.
 
+## Serde Support
+
+Enable the `serde` feature to derive `Serialize`/`Deserialize` on public value types:
+
+```toml
+[dependencies]
+rtlp-lib = { version = "0.5", features = ["serde"] }
+```
+
+**Supported types:** `TlpMode`, `TlpError`, `TlpFmt`, `TlpType`, `AtomicOp`, `FlitTlpType`, `FlitDW0`, `FlitOhcA`
+
+**Not supported:** `TlpPacket` and `TlpPacketHeader` — these contain `TlpHeader`, which uses a bitfield macro that does not support serde derives. If you need to serialize parsed packet data, extract the relevant fields into your own serde-compatible struct.
+
+> **Forward compatibility note:** `TlpMode` and `FlitTlpType` are `#[non_exhaustive]`. New variants added in future versions will serialize correctly on the new version, but deserializing a new variant on an older version will fail. If you persist serialized data to a schema, pin your `rtlp-lib` version accordingly.
+
 ## Documentation
 
 - **[docs/api_guide.md](docs/api_guide.md)** — user-facing guide: parsing flow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 use std::fmt::{self, Display};
 
 use bitfield::bitfield;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Selects the framing mode used to interpret the raw byte buffer.
 ///
@@ -15,6 +17,7 @@ use bitfield::bitfield;
 /// in PCIe 6.0 and uses fixed 256-byte containers.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TlpMode {
     /// Standard non-flit TLP framing (PCIe 1.0 – 5.0).
     /// Bytes are interpreted directly as a TLP header followed by optional payload.
@@ -28,6 +31,7 @@ pub enum TlpMode {
 
 /// Errors that can occur when parsing TLP packets
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TlpError {
     /// Invalid format field value (bits don't match any known format)
     InvalidFormat,
@@ -64,6 +68,7 @@ impl std::error::Error for TlpError {}
 /// TLP format field encoding — encodes header size and whether a data payload is present.
 #[repr(u8)]
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TlpFmt {
     /// 3 DW header, no data payload.
     NoDataHeader3DW = 0b000,
@@ -107,6 +112,7 @@ impl TryFrom<u32> for TlpFmt {
 
 /// Atomic operation discriminant
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AtomicOp {
     /// Fetch-and-Add atomic operation.
     FetchAdd,
@@ -118,6 +124,7 @@ pub enum AtomicOp {
 
 /// Operand width — derived from TLP format: 3DW → 32-bit, 4DW → 64-bit
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AtomicWidth {
     /// 32-bit operand (3 DW header).
     W32,
@@ -169,6 +176,7 @@ impl TryFrom<u32> for TlpFormatEncodingType {
 
 /// High-level TLP transaction type decoded from the DW0 Format and Type fields.
 #[derive(PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TlpType {
     /// 32-bit or 64-bit Memory Read Request.
     MemReadReq,
@@ -1014,6 +1022,7 @@ pub fn new_atomic_req(pkt: &TlpPacket) -> Result<Box<dyn AtomicRequest>, TlpErro
 /// downstream `match` arms.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FlitTlpType {
     /// NOP — smallest flit object, 1 DW base header, no payload.
     Nop,
@@ -1142,6 +1151,7 @@ impl TryFrom<u8> for FlitTlpType {
 ///
 /// Use [`FlitDW0::from_dw0`] to parse from a byte slice.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FlitDW0 {
     /// Decoded TLP type.
     pub tlp_type: FlitTlpType,
@@ -1227,6 +1237,7 @@ impl FlitDW0 {
 /// Use [`FlitOhcA::from_bytes`] to parse from a byte slice that starts at the
 /// first byte of the OHC-A word (i.e. at offset `base_header_dw * 4` in the TLP).
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FlitOhcA {
     /// 20-bit PASID value extracted from bytes 0–2.
     pub pasid: u32,

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -92,10 +92,3 @@ fn json_output_readable() {
     assert!(json.contains("\"length\""));
     assert!(json.contains(": 4"));
 }
-
-#[test]
-fn no_serde_without_feature() {
-    // This test simply verifies compilation — if the serde feature is
-    // disabled, the Serialize/Deserialize derives are absent and this
-    // entire test file is skipped via #![cfg(feature = "serde")].
-}

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -1,0 +1,101 @@
+#![cfg(feature = "serde")]
+
+use rtlp_lib::*;
+
+#[test]
+fn roundtrip_tlp_mode() {
+    let mode = TlpMode::Flit;
+    let json = serde_json::to_string(&mode).unwrap();
+    let back: TlpMode = serde_json::from_str(&json).unwrap();
+    assert_eq!(mode, back);
+}
+
+#[test]
+fn roundtrip_tlp_error() {
+    let err = TlpError::InvalidLength;
+    let json = serde_json::to_string(&err).unwrap();
+    let back: TlpError = serde_json::from_str(&json).unwrap();
+    assert_eq!(err, back);
+}
+
+#[test]
+fn roundtrip_tlp_fmt() {
+    for fmt in [
+        TlpFmt::NoDataHeader3DW,
+        TlpFmt::NoDataHeader4DW,
+        TlpFmt::WithDataHeader3DW,
+        TlpFmt::WithDataHeader4DW,
+        TlpFmt::TlpPrefix,
+    ] {
+        let json = serde_json::to_string(&fmt).unwrap();
+        let back: TlpFmt = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, back);
+    }
+}
+
+#[test]
+fn roundtrip_tlp_type() {
+    let t = TlpType::MemReadReq;
+    let json = serde_json::to_string(&t).unwrap();
+    let back: TlpType = serde_json::from_str(&json).unwrap();
+    assert_eq!(t, back);
+}
+
+#[test]
+fn roundtrip_atomic_op() {
+    for op in [AtomicOp::FetchAdd, AtomicOp::Swap, AtomicOp::CompareSwap] {
+        let json = serde_json::to_string(&op).unwrap();
+        let back: AtomicOp = serde_json::from_str(&json).unwrap();
+        assert_eq!(op, back);
+    }
+}
+
+#[test]
+fn roundtrip_atomic_width() {
+    for w in [AtomicWidth::W32, AtomicWidth::W64] {
+        let json = serde_json::to_string(&w).unwrap();
+        let back: AtomicWidth = serde_json::from_str(&json).unwrap();
+        assert_eq!(w, back);
+    }
+}
+
+#[test]
+fn roundtrip_flit_tlp_type() {
+    let t = FlitTlpType::MemWrite32;
+    let json = serde_json::to_string(&t).unwrap();
+    let back: FlitTlpType = serde_json::from_str(&json).unwrap();
+    assert_eq!(t, back);
+}
+
+#[test]
+fn roundtrip_flit_dw0() {
+    let dw0 = FlitDW0::from_dw0(&[0x40, 0x00, 0x00, 0x04]).unwrap();
+    let json = serde_json::to_string(&dw0).unwrap();
+    let back: FlitDW0 = serde_json::from_str(&json).unwrap();
+    assert_eq!(dw0, back);
+}
+
+#[test]
+fn roundtrip_flit_ohc_a() {
+    let ohc = FlitOhcA::from_bytes(&[0x0A, 0xBC, 0xDE, 0xF3]).unwrap();
+    let json = serde_json::to_string(&ohc).unwrap();
+    let back: FlitOhcA = serde_json::from_str(&json).unwrap();
+    assert_eq!(ohc, back);
+}
+
+#[test]
+fn json_output_readable() {
+    let dw0 = FlitDW0::from_dw0(&[0x40, 0x00, 0x00, 0x04]).unwrap();
+    let json = serde_json::to_string_pretty(&dw0).unwrap();
+    assert!(json.contains("\"tlp_type\""));
+    assert!(json.contains("\"MemWrite32\""));
+    assert!(json.contains("\"length\""));
+    assert!(json.contains(": 4"));
+}
+
+#[test]
+fn no_serde_without_feature() {
+    // This test simply verifies compilation — if the serde feature is
+    // disabled, the Serialize/Deserialize derives are absent and this
+    // entire test file is skipped via #![cfg(feature = "serde")].
+}


### PR DESCRIPTION
### Summary

Adds optional `serde` `Serialize`/`Deserialize` derives for all public data types, gated behind the `serde` feature flag. Zero impact when not enabled.

### Usage

```toml
[dependencies]
rtlp-lib = { version = "0.5", features = ["serde"] }
```

```rust
use rtlp_lib::*;

let dw0 = FlitDW0::from_dw0(&[0x40, 0x00, 0x00, 0x04]).unwrap();
let json = serde_json::to_string_pretty(&dw0).unwrap();
// {
//   "tlp_type": "MemWrite32",
//   "tc": 0,
//   "ohc": 0,
//   "ts": 0,
//   "attr": 0,
//   "length": 4
// }
```

### Annotated types

| Type | Category |
|------|----------|
| `TlpMode` | Framing mode |
| `TlpError` | Error variants |
| `TlpFmt` | Format encoding |
| `TlpType` | Transaction type |
| `AtomicOp` | Atomic operation |
| `AtomicWidth` | Operand width |
| `FlitTlpType` | Flit type codes |
| `FlitDW0` | Parsed flit header |
| `FlitOhcA` | Parsed OHC-A word |

Bitfield structs (`MemRequest3DW`, `ConfigRequest`, etc.) are not annotated since they wrap raw byte arrays managed by the `bitfield` macro — users should serialize the parsed field values via their trait methods instead.

### Tests

11 new tests in `tests/serde_tests.rs`:
- Round-trip JSON serialization for all 9 types
- Human-readable JSON output verification
- Conditional compilation (`#![cfg(feature = "serde")]`)

All existing tests pass with and without the feature. Clippy clean in both configurations.