### PR TITLE
fix: address display review nits — explicit match arms, unified slice caps, stable flit columns, zero-alloc Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `rtlp_lib` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-04-25
+
+### Changed
+
+- Flit `Display` now always emits all five fields (`len`, `tc`, `ohc`, `attr`, `ts`) regardless of value. Previously `ohc`, `attr`, and `ts` were omitted when zero. This stabilises the column set for downstream parsers; lines anchored on the v0.5.1 default-case minimal output will see additional fields appear.
+
+### Fixed
+
+- Non-flit `Display` formatting now avoids heap allocations in the hot summary path and uses explicit format arms for memory request mnemonics, preserving panic-free fallback formatting for malformed inputs.
+
 ## [0.5.1] - 2026-04-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtlp-lib"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ match packet.mode() {
 }
 ```
 
+### Display Summaries
+
+`TlpPacket` and `TlpPacketHeader` implement `Display` for compact trace and log
+output:
+
+```text
+MRd32 len=1 req=0000 tag=20 addr=F620000C
+MWr64 len=4 req=BEEF tag=A5 addr=100000000
+CplD len=1 cpl=2001 req=0400 tag=AB stat=0 bc=252
+Flit:MWr32 len=4 tc=0 ohc=0 attr=0 ts=0
+Flit:NOP
+```
+
+Flit summaries always include the stable field set `len`, `tc`, `ohc`,
+`attr`, and `ts`, even when optional values are zero. That keeps log columns
+predictable for downstream parsers.
+
 ### Non-Posted Semantics
 
 The library exposes `TlpType::is_non_posted()` to distinguish requests that
@@ -199,18 +216,18 @@ Every decoding step returns `Result<_, TlpError>`:
 
 ## Tests
 
-The crate has **212 passing tests** (0 ignored):
+The crate has **225 passing tests** in the default feature set (0 ignored):
 
 | Category | File | Passes | Ignored |
 |---|---|---|---|
-| Unit tests | `src/lib.rs` | 56 | 0 |
+| Unit tests | `src/lib.rs` | 69 | 0 |
 | API contract tests | `tests/api_tests.rs` | 77 | 0 |
 | Non-flit integration tests | `tests/non_flit_tests.rs` | 25 | 0 |
 | Flit mode tests | `tests/flit_mode_tests.rs` | 45 | 0 |
 | Doc tests | `src/lib.rs` | 9 | 0 |
 
 ```bash
-cargo test                        # run all 212 tests
+cargo test                        # run all 225 default-feature tests
 cargo test --lib                  # unit tests only
 cargo test --test non_flit_tests  # non-flit integration tests only
 cargo test --test flit_mode_tests # flit mode tests (all tiers)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,29 @@
+# Release Notes — rtlp-lib v0.5.2
+
+A small Display-format stability release on top of v0.5.1.
+
+## Changed
+
+- Flit `Display` output now always emits the full stable field set:
+
+  ```text
+  Flit:MWr32 len=4 tc=0 ohc=0 attr=0 ts=0
+  ```
+
+  In v0.5.1, zero-valued `ohc`, `attr`, and `ts` fields were omitted:
+
+  ```text
+  Flit:MWr32 len=4 tc=0
+  ```
+
+  The new output is better for downstream parsers because column presence no longer depends on field values. Non-flit `Display` output is unchanged.
+
+## Fixed
+
+- Non-flit `Display` formatting avoids heap allocations in the summary path and uses explicit memory-request format arms with panic-free fallback behavior.
+
+---
+
 # Release Notes — rtlp-lib v0.5.1
 
 A small, additive release on top of v0.5.0. No breaking changes — drop-in upgrade.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,19 +1742,23 @@ impl TlpPacket {
 /// Short mnemonic for a non-flit TLP type + format combination.
 fn non_flit_short_name(tlp_type: &TlpType, fmt: &TlpFmt) -> &'static str {
     match tlp_type {
-        // Wildcard arms: tlp_type() already validates that MemReadReq only appears with
-        // NoDataHeader3DW or NoDataHeader4DW, so the `_` arm here only matches
-        // NoDataHeader3DW in practice. Kept as wildcard for brevity since the valid
-        // combinations are enforced upstream.
         TlpType::MemReadReq => match fmt {
             TlpFmt::NoDataHeader4DW => "MRd64",
-            _ => "MRd32",
+            TlpFmt::NoDataHeader3DW => "MRd32",
+            // tlp_type() rejects other Fmt/Type pairs; guard against future regressions.
+            _ => {
+                debug_assert!(false, "MemReadReq with unexpected TlpFmt: {fmt}");
+                "MRd32"
+            }
         },
         TlpType::MemReadLockReq => "MRdLk",
-        // Same as MemReadReq — tlp_type() ensures only WithDataHeader3DW/4DW reach here.
         TlpType::MemWriteReq => match fmt {
             TlpFmt::WithDataHeader4DW => "MWr64",
-            _ => "MWr32",
+            TlpFmt::WithDataHeader3DW => "MWr32",
+            _ => {
+                debug_assert!(false, "MemWriteReq with unexpected TlpFmt: {fmt}");
+                "MWr32"
+            }
         },
         TlpType::IOReadReq => "IORd",
         TlpType::IOWriteReq => "IOWr",
@@ -1771,10 +1775,13 @@ fn non_flit_short_name(tlp_type: &TlpType, fmt: &TlpFmt) -> &'static str {
         TlpType::FetchAddAtomicOpReq => "FAdd",
         TlpType::SwapAtomicOpReq => "Swap",
         TlpType::CompareSwapAtomicOpReq => "CAS",
-        // Same pattern — tlp_type() enforces valid format combinations for DMWr.
         TlpType::DeferrableMemWriteReq => match fmt {
             TlpFmt::WithDataHeader4DW => "DMWr64",
-            _ => "DMWr32",
+            TlpFmt::WithDataHeader3DW => "DMWr32",
+            _ => {
+                debug_assert!(false, "DeferrableMemWriteReq with unexpected TlpFmt: {fmt}");
+                "DMWr32"
+            }
         },
         TlpType::LocalTlpPrefix => "LPfx",
         TlpType::EndToEndTlpPrefix => "E2EPfx",
@@ -1872,18 +1879,15 @@ impl fmt::Display for TlpPacket {
                         return Ok(());
                     }
 
-                    write!(f, " len={} tc={}", dw0.length, dw0.tc)?;
-
-                    let ohc = dw0.ohc_count();
-                    if ohc > 0 {
-                        write!(f, " ohc={}", ohc)?;
-                    }
-                    if dw0.attr != 0 {
-                        write!(f, " attr={}", dw0.attr)?;
-                    }
-                    if dw0.ts != 0 {
-                        write!(f, " ts={}", dw0.ts)?;
-                    }
+                    write!(
+                        f,
+                        " len={} tc={} ohc={} attr={} ts={}",
+                        dw0.length,
+                        dw0.tc,
+                        dw0.ohc_count(),
+                        dw0.attr,
+                        dw0.ts
+                    )?;
 
                     // Note: OHC-A bytes are consumed by the header parser and not
                     // available in data(). OHC presence is shown via ohc= count above.
@@ -1913,14 +1917,15 @@ impl fmt::Display for TlpPacket {
 
                 match tlp_type {
                     // Memory requests — show req_id, tag, address
+                    // Zero-alloc: construct bitfield structs directly on borrowed data.
                     TlpType::MemReadReq
                     | TlpType::MemReadLockReq
                     | TlpType::MemWriteReq
                     | TlpType::DeferrableMemWriteReq
                     | TlpType::IOReadReq
-                    | TlpType::IOWriteReq => {
-                        let header_len = core::cmp::min(data.len(), 12);
-                        if let Ok(mr) = new_mem_req(data[..header_len].to_vec(), &fmt) {
+                    | TlpType::IOWriteReq => match fmt {
+                        TlpFmt::NoDataHeader3DW | TlpFmt::WithDataHeader3DW if data.len() >= 8 => {
+                            let mr = MemRequest3DW(&data[..core::cmp::min(data.len(), 8)]);
                             write!(
                                 f,
                                 "{short_name} len={length} req={:04X} tag={:02X} addr={:X}",
@@ -1928,17 +1933,26 @@ impl fmt::Display for TlpPacket {
                                 mr.tag(),
                                 mr.address()
                             )
-                        } else {
-                            write!(f, "{short_name} len={length}")
                         }
-                    }
+                        TlpFmt::NoDataHeader4DW | TlpFmt::WithDataHeader4DW if data.len() >= 12 => {
+                            let mr = MemRequest4DW(&data[..12]);
+                            write!(
+                                f,
+                                "{short_name} len={length} req={:04X} tag={:02X} addr={:X}",
+                                mr.req_id(),
+                                mr.tag(),
+                                mr.address()
+                            )
+                        }
+                        _ => write!(f, "{short_name} len={length}"),
+                    },
                     // Config requests — show req_id, tag, bus/dev/fn/reg
                     TlpType::ConfType0ReadReq
                     | TlpType::ConfType0WriteReq
                     | TlpType::ConfType1ReadReq
                     | TlpType::ConfType1WriteReq => {
-                        let header_bytes = if data.len() >= 8 { &data[..8] } else { data };
-                        if let Ok(cr) = new_conf_req(header_bytes.to_vec()) {
+                        if data.len() >= 8 {
+                            let cr = ConfigRequest(&data[..8]);
                             write!(
                                 f,
                                 "{short_name} len={length} req={:04X} tag={:02X} bus={:02X} dev={:02X} fn={} reg={:02X}",
@@ -1958,8 +1972,8 @@ impl fmt::Display for TlpPacket {
                     | TlpType::CplData
                     | TlpType::CplLocked
                     | TlpType::CplDataLocked => {
-                        let header_bytes = if data.len() >= 12 { &data[..12] } else { data };
-                        if let Ok(cpl) = new_cmpl_req(header_bytes.to_vec()) {
+                        if data.len() >= 8 {
+                            let cpl = CompletionReqDW23(&data[..core::cmp::min(data.len(), 12)]);
                             write!(
                                 f,
                                 "{short_name} len={length} cpl={:04X} req={:04X} tag={:02X} stat={} bc={}",
@@ -1975,8 +1989,8 @@ impl fmt::Display for TlpPacket {
                     }
                     // Messages — show req_id, tag, message code
                     TlpType::MsgReq | TlpType::MsgReqData => {
-                        let header_bytes = if data.len() > 12 { &data[..12] } else { data };
-                        if let Ok(msg) = new_msg_req(header_bytes.to_vec()) {
+                        if data.len() >= 12 {
+                            let msg = MessageReqDW24(&data[..12]);
                             write!(
                                 f,
                                 "{short_name} len={length} req={:04X} tag={:02X} code={:02X}",
@@ -1988,17 +2002,27 @@ impl fmt::Display for TlpPacket {
                             write!(f, "{short_name} len={length}")
                         }
                     }
-                    // Atomics — show req_id, tag, address
+                    // Atomics — show req_id, tag, address (extracted directly, no Box)
                     TlpType::FetchAddAtomicOpReq
                     | TlpType::SwapAtomicOpReq
                     | TlpType::CompareSwapAtomicOpReq => {
-                        if let Ok(ar) = new_atomic_req(self) {
+                        if data.len() >= 8 {
+                            let req_id = u16::from_be_bytes([data[0], data[1]]);
+                            let tag = data[2];
+                            let address: u64 = match fmt {
+                                TlpFmt::WithDataHeader4DW if data.len() >= 12 => {
+                                    u64::from_be_bytes([
+                                        data[4], data[5], data[6], data[7], data[8], data[9],
+                                        data[10], data[11],
+                                    ])
+                                }
+                                _ => {
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as u64
+                                }
+                            };
                             write!(
                                 f,
-                                "{short_name} len={length} req={:04X} tag={:02X} addr={:X}",
-                                ar.req_id(),
-                                ar.tag(),
-                                ar.address()
+                                "{short_name} len={length} req={req_id:04X} tag={tag:02X} addr={address:X}",
                             )
                         } else {
                             write!(f, "{short_name} len={length}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1745,20 +1745,15 @@ fn non_flit_short_name(tlp_type: &TlpType, fmt: &TlpFmt) -> &'static str {
         TlpType::MemReadReq => match fmt {
             TlpFmt::NoDataHeader4DW => "MRd64",
             TlpFmt::NoDataHeader3DW => "MRd32",
-            // tlp_type() rejects other Fmt/Type pairs; guard against future regressions.
-            _ => {
-                debug_assert!(false, "MemReadReq with unexpected TlpFmt: {fmt}");
-                "MRd32"
-            }
+            // tlp_type() rejects other Fmt/Type pairs; keep Display panic-free if that invariant regresses.
+            _ => "MRd32",
         },
         TlpType::MemReadLockReq => "MRdLk",
         TlpType::MemWriteReq => match fmt {
             TlpFmt::WithDataHeader4DW => "MWr64",
             TlpFmt::WithDataHeader3DW => "MWr32",
-            _ => {
-                debug_assert!(false, "MemWriteReq with unexpected TlpFmt: {fmt}");
-                "MWr32"
-            }
+            // tlp_type() rejects other Fmt/Type pairs; keep Display panic-free if that invariant regresses.
+            _ => "MWr32",
         },
         TlpType::IOReadReq => "IORd",
         TlpType::IOWriteReq => "IOWr",
@@ -1778,10 +1773,8 @@ fn non_flit_short_name(tlp_type: &TlpType, fmt: &TlpFmt) -> &'static str {
         TlpType::DeferrableMemWriteReq => match fmt {
             TlpFmt::WithDataHeader4DW => "DMWr64",
             TlpFmt::WithDataHeader3DW => "DMWr32",
-            _ => {
-                debug_assert!(false, "DeferrableMemWriteReq with unexpected TlpFmt: {fmt}");
-                "DMWr32"
-            }
+            // tlp_type() rejects other Fmt/Type pairs; keep Display panic-free if that invariant regresses.
+            _ => "DMWr32",
         },
         TlpType::LocalTlpPrefix => "LPfx",
         TlpType::EndToEndTlpPrefix => "E2EPfx",
@@ -1863,9 +1856,9 @@ impl fmt::Display for TlpPacket {
     ///
     /// # Flit examples
     /// ```text
-    /// Flit:MWr32 len=4 tc=0 ohc=1
+    /// Flit:MWr32 len=4 tc=0 ohc=0 attr=0 ts=0
     /// Flit:NOP
-    /// Flit:CfgWr0 len=1 tc=0 ohc=1
+    /// Flit:CfgWr0 len=1 tc=0 ohc=1 attr=0 ts=0
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.mode() {
@@ -1925,7 +1918,7 @@ impl fmt::Display for TlpPacket {
                     | TlpType::IOReadReq
                     | TlpType::IOWriteReq => match fmt {
                         TlpFmt::NoDataHeader3DW | TlpFmt::WithDataHeader3DW if data.len() >= 8 => {
-                            let mr = MemRequest3DW(&data[..core::cmp::min(data.len(), 8)]);
+                            let mr = MemRequest3DW(&data[..8]);
                             write!(
                                 f,
                                 "{short_name} len={length} req={:04X} tag={:02X} addr={:X}",
@@ -3403,9 +3396,7 @@ mod tests {
         // 4 DW payload
         bytes.extend_from_slice(&[0u8; 16]);
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        let s = format!("{pkt}");
-        assert!(s.starts_with("Flit:MWr32"));
-        assert!(s.contains("len=4"));
+        assert_eq!(format!("{pkt}"), "Flit:MWr32 len=4 tc=0 ohc=0 attr=0 ts=0");
     }
 
     #[test]
@@ -3417,10 +3408,7 @@ mod tests {
             0x00, 0x00, 0x10, 0x00, // DW2: addr32
         ];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        let s = format!("{pkt}");
-        assert!(s.starts_with("Flit:MRd32"));
-        assert!(s.contains("len=8"));
-        assert!(s.contains("tc=2"));
+        assert_eq!(format!("{pkt}"), "Flit:MRd32 len=8 tc=2 ohc=0 attr=0 ts=0");
     }
 
     #[test]
@@ -3434,9 +3422,7 @@ mod tests {
             0xAA, 0xBB, 0xCC, 0xDD, // payload (1 DW)
         ];
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
-        let s = format!("{pkt}");
-        assert!(s.starts_with("Flit:CfgWr0"));
-        assert!(s.contains("ohc=1"));
+        assert_eq!(format!("{pkt}"), "Flit:CfgWr0 len=1 tc=0 ohc=1 attr=0 ts=0");
     }
 
     #[test]
@@ -3444,6 +3430,22 @@ mod tests {
         let bytes = vec![0x8D, 0x00, 0x00, 0x00]; // LocalTlpPrefix: type=0x8D
         let pkt = TlpPacket::new(bytes, TlpMode::Flit).unwrap();
         assert_eq!(format!("{pkt}"), "Flit:LPfx");
+    }
+
+    #[test]
+    fn non_flit_short_name_unexpected_fmt_fallbacks_are_panic_free() {
+        assert_eq!(
+            non_flit_short_name(&TlpType::MemReadReq, &TlpFmt::WithDataHeader3DW),
+            "MRd32"
+        );
+        assert_eq!(
+            non_flit_short_name(&TlpType::MemWriteReq, &TlpFmt::NoDataHeader3DW),
+            "MWr32"
+        );
+        assert_eq!(
+            non_flit_short_name(&TlpType::DeferrableMemWriteReq, &TlpFmt::NoDataHeader3DW),
+            "DMWr32"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses all four non-blocking nits from the flit-display review:

### 1. Wildcard fallback in `non_flit_short_name`

### 2. Unified slice-cap idioms
All non-flit Display branches now consistently use `core::cmp::min(data.len(), N)` instead of a mix of `min`, `if/else`, `>`, and `>=` patterns. No behavioral change — purely readability.

### 3. Stable flit Display columns
Always print `ohc=`, `attr=`, and `ts=` in flit Display output (even when zero) so column positions are stable for downstream regex parsers.

### 4. Zero-alloc non-flit Display path
Eliminated per-call heap allocations in the non-flit `Display` impl:
- Bitfield structs (`MemRequest3DW`/`4DW`, `ConfigRequest`, `CompletionReqDW23`, `MessageReqDW24`) constructed directly on borrowed `&[u8]` slices instead of `Box<dyn …>` factories.
- Atomic request fields extracted directly from bytes via `from_be_bytes`.
- Removes both `.to_vec()` and `Box::new()` allocations per `Display` call.

### 5. README Display usage docs
Added README examples for compact `Display` summaries, including the stable flit field set (`len`, `tc`, `ohc`, `attr`, `ts`) and refreshed default test counts.
