### PR TITLE
feat: add DeviceID BDF helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `rtlp_lib` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-04-25
+
+### Added
+
+- `DeviceID` for PCIe Bus/Device/Function identifiers, including raw `u16` conversion, checked construction from BDF parts, standard `BB:DD.F` display formatting, `FromStr` parsing, and serde support when the `serde` feature is enabled.
+- Convenience BDF accessors on request traits: `requester_id()` for memory, configuration, message, and atomic requests; `device_id()` alias for memory requests; and `completer_id()` / `requester_id()` for completions. Existing raw `req_id()` and `cmpl_id()` accessors remain unchanged.
+
 ## [0.5.2] - 2026-04-25
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtlp-lib"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Maciej Grochowski <maciej.grochowski@pm.me>"]

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A Rust crate for parsing PCI Express Transaction Layer Packets (TLPs).
 
-Decode raw TLP byte streams into strongly-typed structs and trait objects.
-The library handles DW0 header decoding (format + type), per-type field
-extraction (requester ID, tag, address, operands, …), and validates
-format/type combinations according to the PCIe specification.
+Decode raw TLP byte streams into strongly-typed structs, trait objects, and
+helper value types. The library handles DW0 header decoding (format + type),
+per-type field extraction (requester ID, tag, address, operands, …), typed
+Bus/Device/Function helpers, and validates format/type combinations according
+to the PCIe specification.
 
 ## Supported TLP Types
 
@@ -61,8 +62,8 @@ match packet.mode() {
                 // data() returns &[u8] — no extra allocation at this call site;
                 // new_mem_req takes impl Into<Vec<u8>> and may allocate internally.
                 let mr = new_mem_req(packet.data(), &tlp_format).unwrap();
-                println!("req_id=0x{:04X}  tag=0x{:02X}  addr=0x{:X}",
-                         mr.req_id(), mr.tag(), mr.address());
+                println!("req_id=0x{:04X} ({})  tag=0x{:02X}  addr=0x{:X}",
+                         mr.req_id(), mr.device_id(), mr.tag(), mr.address());
             }
             TlpType::FetchAddAtomicOpReq |
             TlpType::SwapAtomicOpReq |
@@ -154,6 +155,7 @@ assert!(!TlpType::MemWriteReq.is_non_posted());   // posted
 | `TlpFmt` | Format enum: `NoDataHeader3DW`, `NoDataHeader4DW`, `WithDataHeader3DW`, `WithDataHeader4DW`, `TlpPrefix` |
 | `TlpType` | 21-variant enum covering all decoded non-flit TLP types |
 | `TlpError` | `InvalidFormat`, `InvalidType`, `UnsupportedCombination`, `InvalidLength`, `NotImplemented`, `MissingMandatoryOhc` |
+| `DeviceID` | Typed PCIe Bus/Device/Function identifier with raw `u16` conversion, `BB:DD.F` display formatting, and `FromStr` parsing |
 
 ### Flit Mode Types (PCIe 6.0 Base Spec)
 
@@ -185,14 +187,37 @@ for result in FlitStreamWalker::new(stream) {
 
 | Trait | Fields | Constructor |
 |---|---|---|
-| `MemRequest` | `address()`, `req_id()`, `tag()`, `ldwbe()`, `fdwbe()` | `new_mem_req(bytes, &fmt)` |
-| `ConfigurationRequest` | `req_id()`, `tag()`, `bus_nr()`, `dev_nr()`, `func_nr()`, `ext_reg_nr()`, `reg_nr()` | `new_conf_req(bytes)` |
-| `CompletionRequest` | `cmpl_id()`, `cmpl_stat()`, `bcm()`, `byte_cnt()`, `req_id()`, `tag()`, `laddr()` | `new_cmpl_req(bytes)` |
-| `MessageRequest` | `req_id()`, `tag()`, `msg_code()`, `dw3()`, `dw4()` | `new_msg_req(bytes)` |
-| `AtomicRequest` | `op()`, `width()`, `req_id()`, `tag()`, `address()`, `operand0()`, `operand1()` | `new_atomic_req(&pkt)` |
+| `MemRequest` | `address()`, `req_id()`, `requester_id()`, `device_id()`, `tag()`, `ldwbe()`, `fdwbe()` | `new_mem_req(bytes, &fmt)` |
+| `ConfigurationRequest` | `req_id()`, `requester_id()`, `tag()`, `bus_nr()`, `dev_nr()`, `func_nr()`, `ext_reg_nr()`, `reg_nr()` | `new_conf_req(bytes)` |
+| `CompletionRequest` | `cmpl_id()`, `completer_id()`, `cmpl_stat()`, `bcm()`, `byte_cnt()`, `req_id()`, `requester_id()`, `tag()`, `laddr()` | `new_cmpl_req(bytes)` |
+| `MessageRequest` | `req_id()`, `requester_id()`, `tag()`, `msg_code()`, `dw3()`, `dw4()` | `new_msg_req(bytes)` |
+| `AtomicRequest` | `op()`, `width()`, `req_id()`, `requester_id()`, `tag()`, `address()`, `operand0()`, `operand1()` | `new_atomic_req(&pkt)` |
 
 > **Note:** All `bytes` parameters accept `impl Into<Vec<u8>>` — you can pass `pkt.data()` (`&[u8]`)
 > directly without calling `.to_vec()`. Only `new_mem_req` additionally requires `&TlpFmt`.
+
+### Device IDs
+
+`DeviceID` wraps the 16-bit Requester ID / Completer ID BDF encoding used in
+TLP headers:
+
+```rust
+use rtlp_lib::DeviceID;
+
+let id = DeviceID::from_u16(0x0218);
+assert_eq!(id.bus(), 0x02);
+assert_eq!(id.device(), 0x03);
+assert_eq!(id.function(), 0x00);
+assert_eq!(id.to_u16(), 0x0218);
+assert_eq!(format!("{id}"), "02:03.0");
+
+let parsed: DeviceID = "02:03.1".parse().unwrap();
+assert_eq!(parsed.to_u16(), 0x0219);
+```
+
+Request traits keep their raw `u16` accessors and add parsed helpers such as
+`MemRequest::device_id()`, `requester_id()`, and
+`CompletionRequest::completer_id()`.
 
 ### Atomic-Specific Types
 
@@ -216,18 +241,19 @@ Every decoding step returns `Result<_, TlpError>`:
 
 ## Tests
 
-The crate has **225 passing tests** in the default feature set (0 ignored):
+The crate has **235 passing tests** in the default feature set (0 ignored):
 
 | Category | File | Passes | Ignored |
 |---|---|---|---|
-| Unit tests | `src/lib.rs` | 69 | 0 |
-| API contract tests | `tests/api_tests.rs` | 77 | 0 |
+| Unit tests | `src/lib.rs` | 74 | 0 |
+| API contract tests | `tests/api_tests.rs` | 80 | 0 |
+| DeviceID allocation guard | `tests/device_id_alloc_tests.rs` | 1 | 0 |
 | Non-flit integration tests | `tests/non_flit_tests.rs` | 25 | 0 |
 | Flit mode tests | `tests/flit_mode_tests.rs` | 45 | 0 |
-| Doc tests | `src/lib.rs` | 9 | 0 |
+| Doc tests | `src/lib.rs` | 10 | 0 |
 
 ```bash
-cargo test                        # run all 225 default-feature tests
+cargo test                        # run all 235 default-feature tests
 cargo test --lib                  # unit tests only
 cargo test --test non_flit_tests  # non-flit integration tests only
 cargo test --test flit_mode_tests # flit mode tests (all tiers)
@@ -245,7 +271,7 @@ Enable the `serde` feature to derive `Serialize`/`Deserialize` on public value t
 rtlp-lib = { version = "0.5", features = ["serde"] }
 ```
 
-**Supported types:** `TlpMode`, `TlpError`, `TlpFmt`, `TlpType`, `AtomicOp`, `FlitTlpType`, `FlitDW0`, `FlitOhcA`
+**Supported types:** `TlpMode`, `TlpError`, `TlpFmt`, `TlpType`, `DeviceID`, `AtomicOp`, `AtomicWidth`, `FlitTlpType`, `FlitDW0`, `FlitOhcA`
 
 **Not supported:** `TlpPacket` and `TlpPacketHeader` — these contain `TlpHeader`, which uses a bitfield macro that does not support serde derives. If you need to serialize parsed packet data, extract the relevant fields into your own serde-compatible struct.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+# Release Notes — rtlp-lib v0.5.3
+
+A small additive ergonomics release on top of v0.5.2.
+
+## Added
+
+### `DeviceID` for Bus/Device/Function values
+
+`DeviceID` wraps the 16-bit PCIe Requester ID / Completer ID encoding and exposes bus, device, and function fields directly:
+
+```rust
+use rtlp_lib::DeviceID;
+
+let id = DeviceID::from_u16(0x0218);
+assert_eq!(id.bus(), 0x02);
+assert_eq!(id.device(), 0x03);
+assert_eq!(id.function(), 0x00);
+assert_eq!(format!("{id}"), "02:03.0");
+
+let parsed: DeviceID = "02:03.1".parse().unwrap();
+assert_eq!(parsed.to_u16(), 0x0219);
+```
+
+The type also supports serde when the `serde` feature is enabled.
+
+### Request trait convenience accessors
+
+Request traits now expose parsed BDF helpers while keeping the existing raw integer accessors unchanged:
+
+- `MemRequest::requester_id()` and `MemRequest::device_id()`
+- `ConfigurationRequest::requester_id()`
+- `MessageRequest::requester_id()`
+- `AtomicRequest::requester_id()`
+- `CompletionRequest::completer_id()` and `CompletionRequest::requester_id()`
+
+---
+
 # Release Notes — rtlp-lib v0.5.2
 
 A small Display-format stability release on top of v0.5.1.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! Supports both non-flit (PCIe 1.0–5.0) and flit-mode (PCIe 6.0+) framing.
 
 use std::fmt::{self, Display};
+use std::str::FromStr;
 
 use bitfield::bitfield;
 #[cfg(feature = "serde")]
@@ -413,6 +414,139 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
     }
 }
 
+/// PCIe Bus/Device/Function identifier.
+///
+/// A `DeviceID` wraps the 16-bit Requester ID / Completer ID encoding used by
+/// PCIe TLP headers:
+///
+/// - bits 15:8  — bus number
+/// - bits 7:3   — device number
+/// - bits 2:0   — function number
+///
+/// It formats as standard BDF notation (`BB:DD.F`) and can be parsed from the
+/// same representation.
+///
+/// # Examples
+///
+/// ```
+/// use rtlp_lib::DeviceID;
+///
+/// let id = DeviceID::from_u16(0x0218);
+/// assert_eq!(id.bus(), 0x02);
+/// assert_eq!(id.device(), 0x03);
+/// assert_eq!(id.function(), 0x00);
+/// assert_eq!(id.to_u16(), 0x0218);
+/// assert_eq!(format!("{id}"), "02:03.0");
+///
+/// let parsed: DeviceID = "02:03.1".parse().unwrap();
+/// assert_eq!(parsed.to_u16(), 0x0219);
+/// ```
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DeviceID(u16);
+
+impl DeviceID {
+    /// Creates a `DeviceID` from the raw 16-bit BDF encoding.
+    #[must_use]
+    pub const fn from_u16(raw: u16) -> Self {
+        Self(raw)
+    }
+
+    /// Creates a `DeviceID` from bus, device, and function fields.
+    ///
+    /// Returns `None` when `device > 31` or `function > 7`.
+    #[must_use]
+    pub const fn from_parts(bus: u8, device: u8, function: u8) -> Option<Self> {
+        if device <= 0x1f && function <= 0x07 {
+            Some(Self(
+                ((bus as u16) << 8) | ((device as u16) << 3) | function as u16,
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the raw 16-bit BDF encoding.
+    #[must_use]
+    pub const fn to_u16(self) -> u16 {
+        self.0
+    }
+
+    /// Returns the bus number.
+    #[must_use]
+    pub const fn bus(self) -> u8 {
+        (self.0 >> 8) as u8
+    }
+
+    /// Returns the device number (0..=31).
+    #[must_use]
+    pub const fn device(self) -> u8 {
+        ((self.0 >> 3) & 0x1f) as u8
+    }
+
+    /// Returns the function number (0..=7).
+    #[must_use]
+    pub const fn function(self) -> u8 {
+        (self.0 & 0x07) as u8
+    }
+}
+
+impl From<u16> for DeviceID {
+    fn from(value: u16) -> Self {
+        Self::from_u16(value)
+    }
+}
+
+impl From<DeviceID> for u16 {
+    fn from(value: DeviceID) -> Self {
+        value.to_u16()
+    }
+}
+
+impl Display for DeviceID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:02X}:{:02X}.{:X}",
+            self.bus(),
+            self.device(),
+            self.function()
+        )
+    }
+}
+
+/// Error returned when parsing a `DeviceID` from BDF text fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceIdParseError;
+
+impl Display for DeviceIdParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid PCIe DeviceID; expected BB:DD.F with device <= 1f and function <= 7"
+        )
+    }
+}
+
+impl std::error::Error for DeviceIdParseError {}
+
+impl FromStr for DeviceID {
+    type Err = DeviceIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (bus, rest) = s.split_once(':').ok_or(DeviceIdParseError)?;
+        let (device, function) = rest.split_once('.').ok_or(DeviceIdParseError)?;
+        if bus.len() != 2 || device.len() != 2 || function.len() != 1 {
+            return Err(DeviceIdParseError);
+        }
+        let bus = u8::from_str_radix(bus, 16).map_err(|_| DeviceIdParseError)?;
+        let device = u8::from_str_radix(device, 16).map_err(|_| DeviceIdParseError)?;
+        let function = u8::from_str_radix(function, 16).map_err(|_| DeviceIdParseError)?;
+        Self::from_parts(bus, device, function).ok_or(DeviceIdParseError)
+    }
+}
+
 /// Memory Request Trait:
 /// Applies to 32 and 64 bits requests as well as legacy IO-Request
 /// (Legacy IO Request has the same structure as MemRead3DW)
@@ -420,10 +554,20 @@ impl<T: AsRef<[u8]>> TlpHeader<T> {
 /// Both 3DW (32-bit) and 4DW (64-bit) headers implement this trait
 /// 3DW header is also used for all Legacy IO Requests.
 pub trait MemRequest {
-    /// Returns the Requester ID field (Bus/Device/Function).
+    /// Returns the target address.
     fn address(&self) -> u64;
     /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    fn requester_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.req_id())
+    }
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    ///
+    /// Alias for [`MemRequest::requester_id`].
+    fn device_id(&self) -> DeviceID {
+        self.requester_id()
+    }
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the Last DW Byte Enable nibble.
@@ -570,6 +714,10 @@ pub fn new_mem_req(
 pub trait ConfigurationRequest {
     /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    fn requester_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.req_id())
+    }
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the Bus Number.
@@ -683,6 +831,10 @@ impl<T: AsRef<[u8]>> ConfigurationRequest for ConfigRequest<T> {
 pub trait CompletionRequest {
     /// Returns the 16-bit Completer ID.
     fn cmpl_id(&self) -> u16;
+    /// Returns the Completer ID as a parsed Bus/Device/Function value.
+    fn completer_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.cmpl_id())
+    }
     /// Returns the 3-bit Completion Status field.
     fn cmpl_stat(&self) -> u8;
     /// Returns the BCM (Byte Count Modified) bit.
@@ -691,6 +843,10 @@ pub trait CompletionRequest {
     fn byte_cnt(&self) -> u16;
     /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    fn requester_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.req_id())
+    }
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the 7-bit Lower Address field.
@@ -777,6 +933,10 @@ pub fn new_cmpl_req(bytes: impl Into<Vec<u8>>) -> Result<Box<dyn CompletionReque
 pub trait MessageRequest {
     /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    fn requester_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.req_id())
+    }
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the 8-bit Message Code field.
@@ -860,6 +1020,10 @@ pub trait AtomicRequest: std::fmt::Debug {
     fn width(&self) -> AtomicWidth;
     /// Returns the 16-bit Requester ID.
     fn req_id(&self) -> u16;
+    /// Returns the Requester ID as a parsed Bus/Device/Function value.
+    fn requester_id(&self) -> DeviceID {
+        DeviceID::from_u16(self.req_id())
+    }
     /// Returns the 8-bit Tag field.
     fn tag(&self) -> u8;
     /// Returns the target address.
@@ -2037,6 +2201,61 @@ impl fmt::Display for TlpPacket {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn device_id_from_u16_extracts_bdf_fields() {
+        let id = DeviceID::from_u16(0x0218);
+        assert_eq!(id.bus(), 0x02);
+        assert_eq!(id.device(), 0x03);
+        assert_eq!(id.function(), 0x00);
+        assert_eq!(id.to_u16(), 0x0218);
+        assert_eq!(u16::from(id), 0x0218);
+        assert_eq!(format!("{id}"), "02:03.0");
+    }
+
+    #[test]
+    fn device_id_new_validates_bdf_ranges() {
+        assert_eq!(
+            DeviceID::from_parts(0x02, 0x03, 0x01).unwrap().to_u16(),
+            0x0219
+        );
+        assert!(DeviceID::from_parts(0x02, 0x20, 0x00).is_none());
+        assert!(DeviceID::from_parts(0x02, 0x03, 0x08).is_none());
+    }
+
+    #[test]
+    fn device_id_from_str_parses_standard_bdf_notation() {
+        let id: DeviceID = "C2:1F.7".parse().unwrap();
+        assert_eq!(id.bus(), 0xC2);
+        assert_eq!(id.device(), 0x1F);
+        assert_eq!(id.function(), 0x07);
+        assert_eq!(format!("{id}"), "C2:1F.7");
+    }
+
+    #[test]
+    fn device_id_from_str_rejects_invalid_bdf_notation() {
+        assert!("2:03.0".parse::<DeviceID>().is_err());
+        assert!("02:20.0".parse::<DeviceID>().is_err());
+        assert!("02:03.8".parse::<DeviceID>().is_err());
+        assert!("02-03.0".parse::<DeviceID>().is_err());
+    }
+
+    #[test]
+    fn request_traits_expose_device_ids() {
+        let mem = MemRequest3DW(&[0x02, 0x18, 0x20, 0x0F, 0xF6, 0x20, 0x00, 0x0C]);
+        assert_eq!(mem.requester_id(), DeviceID::from_u16(0x0218));
+        assert_eq!(mem.device_id(), DeviceID::from_u16(0x0218));
+
+        let cfg = ConfigRequest(&[0x02, 0x19, 0x20, 0x0F, 0xC2, 0x08, 0x00, 0x10]);
+        assert_eq!(cfg.requester_id(), DeviceID::from_u16(0x0219));
+
+        let cpl = CompletionReqDW23(&[0x20, 0x01, 0xFF, 0xC2, 0x02, 0x19, 0x20, 0x00]);
+        assert_eq!(cpl.completer_id(), DeviceID::from_u16(0x2001));
+        assert_eq!(cpl.requester_id(), DeviceID::from_u16(0x0219));
+
+        let msg = MessageReqDW24(&[0x02, 0x19, 0x20, 0x7F, 0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(msg.requester_id(), DeviceID::from_u16(0x0219));
+    }
 
     #[test]
     fn tlp_header_type() {

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -5,6 +5,34 @@
 use rtlp_lib::*;
 
 // ============================================================================
+// DeviceID API Tests
+// ============================================================================
+
+#[test]
+fn device_id_type_exists_and_is_public() {
+    let id = DeviceID::from_u16(0x0218);
+    assert_eq!(id.bus(), 0x02);
+    assert_eq!(id.device(), 0x03);
+    assert_eq!(id.function(), 0x00);
+    assert_eq!(id.to_u16(), 0x0218);
+}
+
+#[test]
+fn device_id_implements_display_fromstr_and_conversions() {
+    let id: DeviceID = "02:03.1".parse().unwrap();
+    assert_eq!(format!("{id}"), "02:03.1");
+    assert_eq!(u16::from(id), 0x0219);
+    assert_eq!(DeviceID::from(0x0219), id);
+}
+
+#[test]
+fn device_id_parse_error_is_public_std_error() {
+    let err = "02:20.0".parse::<DeviceID>().unwrap_err();
+    let boxed: Box<dyn std::error::Error> = Box::new(err);
+    assert!(!boxed.to_string().is_empty());
+}
+
+// ============================================================================
 // Error Type API Tests
 // ============================================================================
 

--- a/tests/device_id_alloc_tests.rs
+++ b/tests/device_id_alloc_tests.rs
@@ -1,0 +1,66 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::fmt::{self, Write};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rtlp_lib::DeviceID;
+
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[derive(Default)]
+struct FixedBdfBuf {
+    bytes: [u8; 7],
+    len: usize,
+}
+
+impl FixedBdfBuf {
+    fn clear(&mut self) {
+        self.len = 0;
+    }
+}
+
+impl Write for FixedBdfBuf {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let end = self.len + s.len();
+        if end > self.bytes.len() {
+            return Err(fmt::Error);
+        }
+        self.bytes[self.len..end].copy_from_slice(s.as_bytes());
+        self.len = end;
+        Ok(())
+    }
+}
+
+#[test]
+fn device_id_display_hot_loop_does_not_allocate() {
+    let id = DeviceID::from_parts(0xC2, 0x1F, 0x07).unwrap();
+    let mut out = FixedBdfBuf::default();
+
+    write!(&mut out, "{id}").unwrap();
+    assert_eq!(&out.bytes[..out.len], b"C2:1F.7");
+
+    ALLOCS.store(0, Ordering::Relaxed);
+    for _ in 0..1_000_000 {
+        out.clear();
+        write!(&mut out, "{}", black_box(id)).unwrap();
+        black_box(out.len);
+    }
+
+    assert_eq!(ALLOCS.load(Ordering::Relaxed), 0);
+}

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -3,6 +3,14 @@
 use rtlp_lib::*;
 
 #[test]
+fn roundtrip_device_id() {
+    let id = DeviceID::from_parts(0xC2, 0x1F, 0x07).unwrap();
+    let json = serde_json::to_string(&id).unwrap();
+    let back: DeviceID = serde_json::from_str(&json).unwrap();
+    assert_eq!(id, back);
+}
+
+#[test]
 fn roundtrip_tlp_mode() {
     let mode = TlpMode::Flit;
     let json = serde_json::to_string(&mode).unwrap();


### PR DESCRIPTION
## Summary
Add a public `DeviceID` type for PCIe Bus/Device/Function addressing.

## Motivation
`req_id()`, `cmpl_id()`, and related accessors expose raw `u16` identifiers. `DeviceID` gives users a typed way to inspect, format, parse, serialize, and pass BDF identifiers without manually extracting bus/device/function fields.

## Usage
```rust
use rtlp_lib::DeviceID;

// From raw u16
let id = DeviceID::from_u16(0x0218); // bus=0x02, dev=0x03, fn=0x00
assert_eq!(id.bus(), 0x02);
assert_eq!(id.device(), 0x03);
assert_eq!(id.function(), 0x00);
assert_eq!(id.to_u16(), 0x0218);

// Display: standard BDF notation
assert_eq!(format!("{id}"), "02:03.0");

// FromStr
let id: DeviceID = "02:03.1".parse().unwrap();

// Serde when the `serde` feature is enabled
let json = serde_json::to_string(&id).unwrap();
```

## Integration points
- `MemRequest::device_id() -> DeviceID` convenience over raw `req_id()`.
- `requester_id() -> DeviceID` helpers on memory, configuration, message, and atomic requests.
- `CompletionRequest::completer_id() -> DeviceID` and `CompletionRequest::requester_id() -> DeviceID`.
- Existing raw `req_id() -> u16` and `cmpl_id() -> u16` accessors remain unchanged.

## Validation
- `cargo build`
- `cargo build --features serde`
- `cargo test`
- `cargo test device_id_display_hot_loop_does_not_allocate -- --exact --nocapture`
- `cargo fmt --check`
- `cargo test --features serde`
- `cargo clippy --all-targets --features serde -- -D warnings`
